### PR TITLE
Clean up warning (W1010) and silence warnings (W1029)

### DIFF
--- a/Delphi.WebMock.ResponseStatus.pas
+++ b/Delphi.WebMock.ResponseStatus.pas
@@ -25,6 +25,8 @@
 
 unit Delphi.WebMock.ResponseStatus;
 
+{$WARN DUPLICATE_CTOR_DTOR OFF}
+
 interface
 
 type

--- a/Delphi.WebMock.StringRegExMatcher.pas
+++ b/Delphi.WebMock.StringRegExMatcher.pas
@@ -38,7 +38,7 @@ type
   public
     constructor Create(ARegEx: TRegEx);
     function IsMatch(AValue: string): Boolean;
-    function ToString: string;
+    function ToString: string; reintroduce;
     property RegEx: TRegEx read FRegEx;
   end;
 

--- a/Tests/Delphi.WebMock.Assertion.Tests.pas
+++ b/Tests/Delphi.WebMock.Assertion.Tests.pas
@@ -121,7 +121,7 @@ end;
 
 procedure TWebMockAssertionTests.Delete_GivenMethodAndURI_SetsMatcherValues;
 var
-  LMethod, LURI: string;
+  LURI: string;
 begin
   LURI := '/resource';
 
@@ -141,7 +141,7 @@ end;
 
 procedure TWebMockAssertionTests.Get_GivenMethodAndURI_SetsMatcherValues;
 var
-  LMethod, LURI: string;
+  LURI: string;
 begin
   LURI := '/resource';
 
@@ -161,7 +161,7 @@ end;
 
 procedure TWebMockAssertionTests.Patch_GivenMethodAndURI_SetsMatcherValues;
 var
-  LMethod, LURI: string;
+  LURI: string;
 begin
   LURI := '/resource';
 
@@ -181,7 +181,7 @@ end;
 
 procedure TWebMockAssertionTests.Post_GivenMethodAndURI_SetsMatcherValues;
 var
-  LMethod, LURI: string;
+  LURI: string;
 begin
   LURI := '/resource';
 
@@ -201,7 +201,7 @@ end;
 
 procedure TWebMockAssertionTests.Put_GivenMethodAndURI_SetsMatcherValues;
 var
-  LMethod, LURI: string;
+  LURI: string;
 begin
   LURI := '/resource';
 
@@ -328,8 +328,6 @@ end;
 procedure TWebMockAssertionTests.WithHeaders_Always_ReturnsSelf;
 var
   LHeaders: TStringList;
-  LHeaderName, LHeaderValue: string;
-  I: Integer;
 begin
   LHeaders := TStringList.Create;
 

--- a/Tests/Delphi.WebMock.RequestStub.Tests.pas
+++ b/Tests/Delphi.WebMock.RequestStub.Tests.pas
@@ -179,8 +179,6 @@ end;
 procedure TWebMockRequestStubTests.WithHeaders_Always_ReturnsSelf;
 var
   LHeaders: TStringList;
-  LHeaderName, LHeaderValue: string;
-  I: Integer;
 begin
   LHeaders := TStringList.Create;
 

--- a/Tests/Delphi.WebMock.ResponseContentString.Tests.pas
+++ b/Tests/Delphi.WebMock.ResponseContentString.Tests.pas
@@ -76,7 +76,6 @@ end;
 procedure TWebMockResponseContentStringTests.ContentStream_Always_ReturnsAStringStreamContainingString;
 var
   LExpected: string;
-  LStream: TStream;
 begin
   LExpected := 'A String Value';
   WebMockResponseContentString := TWebMockResponseContentString.Create(LExpected);

--- a/Tests/Features/Delphi.WebMock.Assertions.Tests.pas
+++ b/Tests/Features/Delphi.WebMock.Assertions.Tests.pas
@@ -321,7 +321,6 @@ end;
 procedure TWebMockAssertionsTests.WasRequestedWithHeaderRegEx_MatchingRequest_Passes;
 var
   LHeaderName: string;
-  LPattern: TRegEx;
 begin
   LHeaderName := 'Header-1';
   WebClient.Get(
@@ -347,7 +346,6 @@ end;
 procedure TWebMockAssertionsTests.WasRequestedWithHeaderRegEx_NotMatchingRequest_Fails;
 var
   LHeaderName: string;
-  LPattern: TRegEx;
 begin
   LHeaderName := 'Header-1';
   WebClient.Get(

--- a/Tests/Features/Delphi.WebMock.ResponsesWithBody.Tests.pas
+++ b/Tests/Features/Delphi.WebMock.ResponsesWithBody.Tests.pas
@@ -117,7 +117,6 @@ procedure TWebMockResponsesWithBodyTests.Response_WhenWithBodyIsAString_ReturnsS
 var
   LExpectedContent: string;
   LResponse: IHTTPResponse;
-  LHeader: string;
   LContentText: string;
 begin
   LExpectedContent := 'Body Text';
@@ -132,7 +131,6 @@ end;
 procedure TWebMockResponsesWithBodyTests.Response_WhenWithBodyIsString_ReturnsUTF8CharSet;
 var
   LResponse: IHTTPResponse;
-  LHeader: string;
 begin
   WebMock.StubRequest('GET', '/text').ToRespond.WithBody('UTF-8 Text');
   LResponse := WebClient.Get(WebMock.URLFor('text'));


### PR DESCRIPTION
Resolves #17.

* Warning W1010 is solved by reintroducing the `TWebMockStringRegExMatcher#ToString` method.
* Warning W1029 has been turned off in the unit `Delphi.WebMock.ResponseStatus`.
* Also removes a number of unused local variables in tests to remove compiler hints when running tests.