### PR TITLE
Add dynamic request matching

### DIFF
--- a/Delphi.WebMock.Static.RequestStub.pas
+++ b/Delphi.WebMock.Static.RequestStub.pas
@@ -1,0 +1,165 @@
+{******************************************************************************}
+{                                                                              }
+{           Delphi-WebMocks                                                    }
+{                                                                              }
+{           Copyright (c) 2019-2020 Richard Hatherall                          }
+{                                                                              }
+{           richard@appercept.com                                              }
+{           https://appercept.com                                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{   Licensed under the Apache License, Version 2.0 (the "License");            }
+{   you may not use this file except in compliance with the License.           }
+{   You may obtain a copy of the License at                                    }
+{                                                                              }
+{       http://www.apache.org/licenses/LICENSE-2.0                             }
+{                                                                              }
+{   Unless required by applicable law or agreed to in writing, software        }
+{   distributed under the License is distributed on an "AS IS" BASIS,          }
+{   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   }
+{   See the License for the specific language governing permissions and        }
+{   limitations under the License.                                             }
+{                                                                              }
+{******************************************************************************}
+
+unit Delphi.WebMock.Static.RequestStub;
+
+interface
+
+uses
+  Delphi.WebMock.HTTP.Messages, Delphi.WebMock.HTTP.RequestMatcher,
+  Delphi.WebMock.RequestStub, Delphi.WebMock.Response,
+  Delphi.WebMock.ResponseStatus,
+  IdCustomHTTPServer,
+  System.Classes, System.Generics.Collections, System.RegularExpressions;
+
+type
+  TWebMockStaticRequestStub = class(TInterfacedObject, IWebMockRequestStub)
+  private
+    FMatcher: TWebMockHTTPRequestMatcher;
+    FResponse: TWebMockResponse;
+  public
+    constructor Create(AMatcher: TWebMockHTTPRequestMatcher);
+    destructor Destroy; override;
+    function ToRespond(AResponseStatus: TWebMockResponseStatus = nil)
+      : TWebMockResponse;
+    function WithBody(const AContent: string): TWebMockStaticRequestStub; overload;
+    function WithBody(const APattern: TRegEx): TWebMockStaticRequestStub; overload;
+    function WithHeader(AName, AValue: string): TWebMockStaticRequestStub; overload;
+    function WithHeader(AName: string; APattern: TRegEx)
+      : TWebMockStaticRequestStub; overload;
+    function WithHeaders(AHeaders: TStringList): TWebMockStaticRequestStub;
+
+    // IWebMockRequestStub
+    function IsMatch(ARequest: IWebMockHTTPRequest): Boolean;
+    function GetResponse: TWebMockResponse;
+    procedure SetResponse(const AResponse: TWebMockResponse);
+    function ToString: string; override;
+    property Response: TWebMockResponse read GetResponse write SetResponse;
+
+    property Matcher: TWebMockHTTPRequestMatcher read FMatcher;
+  end;
+
+implementation
+
+uses
+  Delphi.WebMock.StringWildcardMatcher, Delphi.WebMock.StringRegExMatcher,
+  System.SysUtils;
+
+{ TWebMockRequestStub }
+
+constructor TWebMockStaticRequestStub.Create(AMatcher: TWebMockHTTPRequestMatcher);
+begin
+  inherited Create;
+  FMatcher := AMatcher;
+  FResponse := TWebMockResponse.Create;
+end;
+
+destructor TWebMockStaticRequestStub.Destroy;
+
+begin
+  FResponse.Free;
+  FMatcher.Free;
+  inherited;
+end;
+
+function TWebMockStaticRequestStub.GetResponse: TWebMockResponse;
+begin
+  Result := FResponse;
+end;
+
+function TWebMockStaticRequestStub.IsMatch(
+  ARequest: IWebMockHTTPRequest): Boolean;
+begin
+  Result := Matcher.IsMatch(ARequest);
+end;
+
+procedure TWebMockStaticRequestStub.SetResponse(
+  const AResponse: TWebMockResponse);
+begin
+
+end;
+
+function TWebMockStaticRequestStub.ToRespond(
+  AResponseStatus: TWebMockResponseStatus = nil): TWebMockResponse;
+begin
+  if Assigned(AResponseStatus) then
+    Response.Status := AResponseStatus;
+
+  Result := Response;
+end;
+
+function TWebMockStaticRequestStub.ToString: string;
+begin
+  Result := Format('%s' + ^I + '%s', [Matcher.ToString, Response.ToString]);
+end;
+
+function TWebMockStaticRequestStub.WithHeader(AName, AValue: string): TWebMockStaticRequestStub;
+begin
+  Matcher.Headers.AddOrSetValue(
+    AName,
+    TWebMockStringWildcardMatcher.Create(AValue)
+  );
+
+  Result := Self;
+end;
+
+function TWebMockStaticRequestStub.WithBody(
+  const AContent: string): TWebMockStaticRequestStub;
+begin
+  Matcher.Body := TWebMockStringWildcardMatcher.Create(AContent);
+
+  Result := Self;
+end;
+
+function TWebMockStaticRequestStub.WithBody(
+  const APattern: TRegEx): TWebMockStaticRequestStub;
+begin
+  Matcher.Body := TWebMockStringRegExMatcher.Create(APattern);
+
+  Result := Self;
+end;
+
+function TWebMockStaticRequestStub.WithHeader(AName: string;
+  APattern: TRegEx): TWebMockStaticRequestStub;
+begin
+  Matcher.Headers.AddOrSetValue(
+    AName,
+    TWebMockStringRegExMatcher.Create(APattern)
+  );
+
+  Result := Self;
+end;
+
+function TWebMockStaticRequestStub.WithHeaders(AHeaders: TStringList): TWebMockStaticRequestStub;
+var
+  I: Integer;
+begin
+  for I := 0 to AHeaders.Count - 1 do
+    WithHeader(AHeaders.Names[I], AHeaders.ValueFromIndex[I]);
+
+  Result := Self;
+end;
+
+end.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ WebMock.StubRequest('*', '*')
 
 NOTE: Be sure to add `System.RegularExpressions` to your uses clause.
 
+#### Request matching by predicate function
+If matching logic is required to be more complex than the simple matching, a
+predicate function can be provided in the test to allow custom inspection/logic
+for matching a request. The anonymous predicate function will receive an
+`IWebMockHTTPRequest` object for inspecting the request. If the predicate
+function returns `True` then the stub will be regarded as a match, if returning
+`False` it will not be matched.
+
+Example stub with predicate function:
+```Delphi
+WebMock.StubRequest(
+  function(ARequest: IWebMockHTTPRequest): Boolean
+  begin
+    Result := True; // Return False to ignore request.
+  end
+);
+```
+
 #### Stubbed Response Codes
 By default a response status will be `200 OK` for a stubbed request. If a
 request is made to `TWebMock` without a registered stub it will respond

--- a/Tests/Delphi.WebMock.Dynamic.RequestStub.Tests.pas
+++ b/Tests/Delphi.WebMock.Dynamic.RequestStub.Tests.pas
@@ -1,0 +1,170 @@
+{******************************************************************************}
+{                                                                              }
+{           Delphi-WebMocks                                                    }
+{                                                                              }
+{           Copyright (c) 2020 Richard Hatherall                               }
+{                                                                              }
+{           richard@appercept.com                                              }
+{           https://appercept.com                                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{   Licensed under the Apache License, Version 2.0 (the "License");            }
+{   you may not use this file except in compliance with the License.           }
+{   You may obtain a copy of the License at                                    }
+{                                                                              }
+{       http://www.apache.org/licenses/LICENSE-2.0                             }
+{                                                                              }
+{   Unless required by applicable law or agreed to in writing, software        }
+{   distributed under the License is distributed on an "AS IS" BASIS,          }
+{   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   }
+{   See the License for the specific language governing permissions and        }
+{   limitations under the License.                                             }
+{                                                                              }
+{******************************************************************************}
+
+unit Delphi.WebMock.Dynamic.RequestStub.Tests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  Delphi.WebMock.Dynamic.RequestStub;
+
+type
+  [TestFixture]
+  TWebMockDynamicRequestStubTests = class(TObject)
+  private
+    StubbedRequest: TWebMockDynamicRequestStub;
+  public
+    [Test]
+    procedure Class_Always_ImplementsIWebMockRequestStub;
+    [Test]
+    procedure IsMatch_WhenInitializedWithFunctionReturningTrue_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WhenInitializedWithFunctionReturningFalse_ReturnsFalse;
+    [Test]
+    procedure GetResponse_Always_GetsResponse;
+    [Test]
+    procedure SetResponse_Always_SetsResponse;
+    [Test]
+    procedure ToRespond_Always_ReturnsAResponseStub;
+    [Test]
+    procedure ToRespond_WithNoArguments_DoesNotRaiseException;
+    [Test]
+    procedure ToRespond_WithNoArguments_DoesNotChangeStatus;
+    [Test]
+    procedure ToString_Always_ReturnsAStringDescription;
+  end;
+
+implementation
+
+uses
+  Delphi.WebMock.HTTP.Messages, Delphi.WebMock.HTTP.Request,
+  Delphi.WebMock.RequestStub, Delphi.WebMock.Response,
+  Delphi.WebMock.ResponseStatus,
+  Mock.Indy.HTTPRequestInfo,
+  IdCustomHTTPServer;
+
+{ TWebMockDynamicRequestStubTests }
+
+procedure TWebMockDynamicRequestStubTests.Class_Always_ImplementsIWebMockRequestStub;
+var
+  LSubject: IInterface;
+begin
+  LSubject := TWebMockDynamicRequestStub.Create(
+    function(ARequest: IWebMockHTTPRequest): Boolean
+    begin
+      Result := False;
+    end
+  );
+
+  Assert.Implements<IWebMockRequestStub>(LSubject);
+end;
+
+procedure TWebMockDynamicRequestStubTests.GetResponse_Always_GetsResponse;
+begin
+  Assert.IsTrue(StubbedRequest.GetResponse <> nil, 'GetResponse should return a response');
+end;
+
+procedure TWebMockDynamicRequestStubTests.IsMatch_WhenInitializedWithFunctionReturningFalse_ReturnsFalse;
+var
+  LRequestInfo: TIdHTTPRequestInfo;
+  LRequest: IWebMockHTTPRequest;
+begin
+  LRequestInfo := TMockIdHTTPRequestInfo.Mock('GET', '/');
+  LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
+
+  StubbedRequest := TWebMockDynamicRequestStub.Create(
+    function(ARequest: IWebMockHTTPRequest): Boolean
+    begin
+      Result := False;
+    end
+  );
+
+  Assert.IsFalse(StubbedRequest.IsMatch(LRequest));
+end;
+
+procedure TWebMockDynamicRequestStubTests.IsMatch_WhenInitializedWithFunctionReturningTrue_ReturnsTrue;
+var
+  LRequestInfo: TIdHTTPRequestInfo;
+  LRequest: IWebMockHTTPRequest;
+begin
+  LRequestInfo := TMockIdHTTPRequestInfo.Mock('GET', '/');
+  LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
+
+  StubbedRequest := TWebMockDynamicRequestStub.Create(
+    function(ARequest: IWebMockHTTPRequest): Boolean
+    begin
+      Result := True;
+    end
+  );
+
+  Assert.IsTrue(StubbedRequest.IsMatch(LRequest));
+end;
+
+procedure TWebMockDynamicRequestStubTests.SetResponse_Always_SetsResponse;
+var
+  LResponse: TWebMockResponse;
+begin
+  LResponse := TWebMockResponse.Create;
+
+  StubbedRequest.SetResponse(LResponse);
+
+  Assert.AreSame(LResponse, StubbedRequest.Response, 'SetResponse should set Response');
+end;
+
+procedure TWebMockDynamicRequestStubTests.ToRespond_Always_ReturnsAResponseStub;
+begin
+  Assert.IsTrue(StubbedRequest.ToRespond is TWebMockResponse);
+end;
+
+procedure TWebMockDynamicRequestStubTests.ToRespond_WithNoArguments_DoesNotChangeStatus;
+var
+  LExpectedStatus: TWebMockResponseStatus;
+begin
+  LExpectedStatus := StubbedRequest.Response.Status;
+
+  StubbedRequest.ToRespond;
+
+  Assert.AreSame(LExpectedStatus, StubbedRequest.Response.Status);
+end;
+
+procedure TWebMockDynamicRequestStubTests.ToRespond_WithNoArguments_DoesNotRaiseException;
+begin
+  Assert.WillNotRaiseAny(
+    procedure
+    begin
+      StubbedRequest.ToRespond;
+    end
+  );
+end;
+
+procedure TWebMockDynamicRequestStubTests.ToString_Always_ReturnsAStringDescription;
+begin
+  Assert.IsTrue(Length(StubbedRequest.ToString) > 0, 'ToString should return a description');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TWebMockDynamicRequestStubTests);
+end.

--- a/Tests/Delphi.WebMock.Static.RequestStub.Tests.pas
+++ b/Tests/Delphi.WebMock.Static.RequestStub.Tests.pas
@@ -23,25 +23,27 @@
 {                                                                              }
 {******************************************************************************}
 
-unit Delphi.WebMock.RequestStub.Tests;
+unit Delphi.WebMock.Static.RequestStub.Tests;
 
 interface
 
 uses
   DUnitX.TestFramework,
-  Delphi.WebMock.RequestStub;
+  Delphi.WebMock.Static.RequestStub;
 
 type
 
   [TestFixture]
-  TWebMockRequestStubTests = class(TObject)
+  TWebMockStaticRequestStubTests = class(TObject)
   private
-    StubbedRequest: TWebMockRequestStub;
+    StubbedRequest: TWebMockStaticRequestStub;
   public
     [Setup]
     procedure Setup;
     [TearDown]
     procedure TearDown;
+    [Test]
+    procedure Class_Always_ImplementsIWebMockRequestStub;
     [Test]
     procedure ToRespond_Always_ReturnsAResponseStub;
     [Test]
@@ -77,34 +79,44 @@ type
 implementation
 
 uses
-  Delphi.WebMock.HTTP.RequestMatcher, Delphi.WebMock.Response,
-  Delphi.WebMock.ResponseStatus, Delphi.WebMock.StringMatcher,
-  Delphi.WebMock.StringWildcardMatcher, Delphi.WebMock.StringRegExMatcher,
+  Delphi.WebMock.HTTP.RequestMatcher, Delphi.WebMock.RequestStub,
+  Delphi.WebMock.Response, Delphi.WebMock.ResponseStatus,
+  Delphi.WebMock.StringMatcher, Delphi.WebMock.StringWildcardMatcher,
+  Delphi.WebMock.StringRegExMatcher,
   IdCustomHTTPServer,
   Mock.Indy.HTTPRequestInfo,
   System.Classes, System.RegularExpressions;
 
 { TWebMockRequestStubTests }
 
-procedure TWebMockRequestStubTests.Setup;
+procedure TWebMockStaticRequestStubTests.Class_Always_ImplementsIWebMockRequestStub;
+var
+  LSubject: IInterface;
+begin
+  LSubject := StubbedRequest;
+
+  Assert.Implements<IWebMockRequestStub>(LSubject);
+end;
+
+procedure TWebMockStaticRequestStubTests.Setup;
 var
   LMatcher: TWebMockHTTPRequestMatcher;
 begin
   LMatcher := TWebMockHTTPRequestMatcher.Create('');
-  StubbedRequest := TWebMockRequestStub.Create(LMatcher);
+  StubbedRequest := TWebMockStaticRequestStub.Create(LMatcher);
 end;
 
-procedure TWebMockRequestStubTests.TearDown;
+procedure TWebMockStaticRequestStubTests.TearDown;
 begin
   StubbedRequest := nil;
 end;
 
-procedure TWebMockRequestStubTests.ToRespond_Always_ReturnsAResponseStub;
+procedure TWebMockStaticRequestStubTests.ToRespond_Always_ReturnsAResponseStub;
 begin
   Assert.IsTrue(StubbedRequest.ToRespond is TWebMockResponse);
 end;
 
-procedure TWebMockRequestStubTests.ToRespond_WithNoArguments_DoesNotRaiseException;
+procedure TWebMockStaticRequestStubTests.ToRespond_WithNoArguments_DoesNotRaiseException;
 begin
   Assert.WillNotRaiseAny(
   procedure
@@ -113,7 +125,7 @@ begin
   end);
 end;
 
-procedure TWebMockRequestStubTests.ToRespond_WithNoArguments_DoesNotChangeStatus;
+procedure TWebMockStaticRequestStubTests.ToRespond_WithNoArguments_DoesNotChangeStatus;
 var
   LExpectedStatus: TWebMockResponseStatus;
 begin
@@ -124,7 +136,7 @@ begin
   Assert.AreSame(LExpectedStatus, StubbedRequest.Response.Status);
 end;
 
-procedure TWebMockRequestStubTests.ToRespond_WithResponse_SetsResponseStatus;
+procedure TWebMockStaticRequestStubTests.ToRespond_WithResponse_SetsResponseStatus;
 var
   LResponse: TWebMockResponseStatus;
 begin
@@ -135,7 +147,7 @@ begin
   Assert.AreSame(LResponse, StubbedRequest.Response.Status);
 end;
 
-procedure TWebMockRequestStubTests.WithBody_GivenRegEx_ReturnsSelf;
+procedure TWebMockStaticRequestStubTests.WithBody_GivenRegEx_ReturnsSelf;
 begin
   Assert.AreSame(
     StubbedRequest,
@@ -143,7 +155,7 @@ begin
   );
 end;
 
-procedure TWebMockRequestStubTests.WithBody_GivenRegEx_SetsValueForContent;
+procedure TWebMockStaticRequestStubTests.WithBody_GivenRegEx_SetsValueForContent;
 var
   LPattern: TRegEx;
 begin
@@ -157,12 +169,12 @@ begin
   );
 end;
 
-procedure TWebMockRequestStubTests.WithBody_GivenString_ReturnsSelf;
+procedure TWebMockStaticRequestStubTests.WithBody_GivenString_ReturnsSelf;
 begin
   Assert.AreSame(StubbedRequest, StubbedRequest.WithBody('Hello.'));
 end;
 
-procedure TWebMockRequestStubTests.WithBody_GivenString_SetsValueForContent;
+procedure TWebMockStaticRequestStubTests.WithBody_GivenString_SetsValueForContent;
 var
   LContent: string;
 begin
@@ -176,7 +188,7 @@ begin
   );
 end;
 
-procedure TWebMockRequestStubTests.WithHeaders_Always_ReturnsSelf;
+procedure TWebMockStaticRequestStubTests.WithHeaders_Always_ReturnsSelf;
 var
   LHeaders: TStringList;
 begin
@@ -187,7 +199,7 @@ begin
   LHeaders.Free;
 end;
 
-procedure TWebMockRequestStubTests.WithHeaders_Always_SetsAllValues;
+procedure TWebMockStaticRequestStubTests.WithHeaders_Always_SetsAllValues;
 var
   LHeaders: TStringList;
   LHeaderName, LHeaderValue: string;
@@ -212,7 +224,7 @@ begin
   LHeaders.Free;
 end;
 
-procedure TWebMockRequestStubTests.WithHeader_Always_OverwritesExistingValues;
+procedure TWebMockStaticRequestStubTests.WithHeader_Always_OverwritesExistingValues;
 var
   LHeaderName, LHeaderValue1, LHeaderValue2: string;
   LMatcher: IStringMatcher;
@@ -228,7 +240,7 @@ begin
   Assert.AreNotSame(LMatcher, StubbedRequest.Matcher.Headers[LHeaderName]);
 end;
 
-procedure TWebMockRequestStubTests.WithHeader_GivenRegEx_ReturnsSelf;
+procedure TWebMockStaticRequestStubTests.WithHeader_GivenRegEx_ReturnsSelf;
 begin
   Assert.AreSame(
     StubbedRequest,
@@ -236,7 +248,7 @@ begin
   );
 end;
 
-procedure TWebMockRequestStubTests.WithHeader_GivenRegEx_SetsPatternForHeader;
+procedure TWebMockStaticRequestStubTests.WithHeader_GivenRegEx_SetsPatternForHeader;
 var
   LHeaderName: string;
   LHeaderPattern: TRegEx;
@@ -252,12 +264,12 @@ begin
   );
 end;
 
-procedure TWebMockRequestStubTests.WithHeader_GivenString_ReturnsSelf;
+procedure TWebMockStaticRequestStubTests.WithHeader_GivenString_ReturnsSelf;
 begin
   Assert.AreSame(StubbedRequest, StubbedRequest.WithHeader('Header', 'Value'));
 end;
 
-procedure TWebMockRequestStubTests.WithHeader_GivenString_SetsValueForHeader;
+procedure TWebMockStaticRequestStubTests.WithHeader_GivenString_SetsValueForHeader;
 var
   LHeaderName, LHeaderValue: string;
 begin
@@ -273,5 +285,5 @@ begin
 end;
 
 initialization
-  TDUnitX.RegisterTestFixture(TWebMockRequestStubTests);
+  TDUnitX.RegisterTestFixture(TWebMockStaticRequestStubTests);
 end.

--- a/Tests/Delphi.WebMock.Tests.pas
+++ b/Tests/Delphi.WebMock.Tests.pas
@@ -75,7 +75,7 @@ type
 implementation
 
 uses
-  Delphi.WebMock.RequestStub,
+  Delphi.WebMock.RequestStub, Delphi.WebMock.Static.RequestStub,
   System.Net.HttpClient, System.RegularExpressions, System.StrUtils,
   TestHelpers;
 
@@ -176,12 +176,12 @@ end;
 
 procedure TWebMockTests.StubRequest_WithRegExURI_ReturnsARequestStub;
 begin
-  Assert.IsTrue(WebMock.StubRequest('GET', TRegEx.Create('.*')) is TWebMockRequestStub);
+  Assert.IsTrue(WebMock.StubRequest('GET', TRegEx.Create('.*')) is TWebMockStaticRequestStub);
 end;
 
 procedure TWebMockTests.StubRequest_WithStringURI_ReturnsARequestStub;
 begin
-  Assert.IsTrue(WebMock.StubRequest('GET', '/') is TWebMockRequestStub);
+  Assert.IsTrue(WebMock.StubRequest('GET', '/') is TWebMockStaticRequestStub);
 end;
 
 initialization

--- a/Tests/Delphi.WebMocks.Tests.dpr
+++ b/Tests/Delphi.WebMocks.Tests.dpr
@@ -17,8 +17,8 @@ uses
   Delphi.WebMock.Tests in 'Delphi.WebMock.Tests.pas',
   Delphi.WebMock in '..\Delphi.WebMock.pas',
   TestHelpers in 'TestHelpers.pas',
-  Delphi.WebMock.RequestStub.Tests in 'Delphi.WebMock.RequestStub.Tests.pas',
-  Delphi.WebMock.RequestStub in '..\Delphi.WebMock.RequestStub.pas',
+  Delphi.WebMock.Static.RequestStub.Tests in 'Delphi.WebMock.Static.RequestStub.Tests.pas',
+  Delphi.WebMock.Static.RequestStub in '..\Delphi.WebMock.Static.RequestStub.pas',
   Delphi.WebMock.HTTP.RequestMatcher.Tests in 'Delphi.WebMock.HTTP.RequestMatcher.Tests.pas',
   Delphi.WebMock.HTTP.RequestMatcher in '..\Delphi.WebMock.HTTP.RequestMatcher.pas',
   Mock.Indy.HTTPRequestInfo in 'Mock.Indy.HTTPRequestInfo.pas',
@@ -49,7 +49,11 @@ uses
   Delphi.WebMock.Responses.Tests in 'Features\Delphi.WebMock.Responses.Tests.pas',
   Delphi.WebMock.Assertions.Tests in 'Features\Delphi.WebMock.Assertions.Tests.pas',
   Delphi.WebMock.Assertion in '..\Delphi.WebMock.Assertion.pas',
-  Delphi.WebMock.Assertion.Tests in 'Delphi.WebMock.Assertion.Tests.pas';
+  Delphi.WebMock.Assertion.Tests in 'Delphi.WebMock.Assertion.Tests.pas',
+  Delphi.WebMock.DynamicMatching.Tests in 'Features\Delphi.WebMock.DynamicMatching.Tests.pas',
+  Delphi.WebMock.Dynamic.RequestStub.Tests in 'Delphi.WebMock.Dynamic.RequestStub.Tests.pas',
+  Delphi.WebMock.Dynamic.RequestStub in '..\Delphi.WebMock.Dynamic.RequestStub.pas',
+  Delphi.WebMock.RequestStub in '..\Delphi.WebMock.RequestStub.pas';
 
 var
   Runner: ITestRunner;

--- a/Tests/Delphi.WebMocks.Tests.dproj
+++ b/Tests/Delphi.WebMocks.Tests.dproj
@@ -112,8 +112,8 @@
         <DCCReference Include="Delphi.WebMock.Tests.pas"/>
         <DCCReference Include="..\Delphi.WebMock.pas"/>
         <DCCReference Include="TestHelpers.pas"/>
-        <DCCReference Include="Delphi.WebMock.RequestStub.Tests.pas"/>
-        <DCCReference Include="..\Delphi.WebMock.RequestStub.pas"/>
+        <DCCReference Include="Delphi.WebMock.Static.RequestStub.Tests.pas"/>
+        <DCCReference Include="..\Delphi.WebMock.Static.RequestStub.pas"/>
         <DCCReference Include="Delphi.WebMock.HTTP.RequestMatcher.Tests.pas"/>
         <DCCReference Include="..\Delphi.WebMock.HTTP.RequestMatcher.pas"/>
         <DCCReference Include="Mock.Indy.HTTPRequestInfo.pas"/>
@@ -145,6 +145,10 @@
         <DCCReference Include="Features\Delphi.WebMock.Assertions.Tests.pas"/>
         <DCCReference Include="..\Delphi.WebMock.Assertion.pas"/>
         <DCCReference Include="Delphi.WebMock.Assertion.Tests.pas"/>
+        <DCCReference Include="Features\Delphi.WebMock.DynamicMatching.Tests.pas"/>
+        <DCCReference Include="Delphi.WebMock.Dynamic.RequestStub.Tests.pas"/>
+        <DCCReference Include="..\Delphi.WebMock.Dynamic.RequestStub.pas"/>
+        <DCCReference Include="..\Delphi.WebMock.RequestStub.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Tests/Features/Delphi.WebMock.DynamicMatching.Tests.pas
+++ b/Tests/Features/Delphi.WebMock.DynamicMatching.Tests.pas
@@ -1,0 +1,161 @@
+{******************************************************************************}
+{                                                                              }
+{           Delphi-WebMocks                                                    }
+{                                                                              }
+{           Copyright (c) 2020 Richard Hatherall                               }
+{                                                                              }
+{           richard@appercept.com                                              }
+{           https://appercept.com                                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{   Licensed under the Apache License, Version 2.0 (the "License");            }
+{   you may not use this file except in compliance with the License.           }
+{   You may obtain a copy of the License at                                    }
+{                                                                              }
+{       http://www.apache.org/licenses/LICENSE-2.0                             }
+{                                                                              }
+{   Unless required by applicable law or agreed to in writing, software        }
+{   distributed under the License is distributed on an "AS IS" BASIS,          }
+{   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   }
+{   See the License for the specific language governing permissions and        }
+{   limitations under the License.                                             }
+{                                                                              }
+{******************************************************************************}
+
+unit Delphi.WebMock.DynamicMatching.Tests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  Delphi.WebMock;
+
+type
+  [TestFixture]
+  TWebMockDynamicMatchingTests = class(TObject)
+  private
+    WebMock: TWebMock;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+    [Test]
+    procedure DynamicMatcher_ReturningTrue_RespondsOK;
+    [Test]
+    procedure DynamicMatcher_ReturningFalse_RespondsNotImplemented;
+    [Test]
+    procedure DynamicMatcher_OnEachRequest_ProvidesRequestForEvaluation;
+    [Test]
+    procedure DynamicMatcher_OnEachRequest_CanChooseToRespond;
+    [Test]
+    procedure DynamicMatcher_Always_CanBeChainedToProvideCustomResponses;
+  end;
+
+implementation
+
+uses
+  Delphi.WebMock.HTTP.Messages, Delphi.WebMock.ResponseStatus,
+  System.Classes, System.Net.HttpClient,
+  TestHelpers;
+
+{ TWebMockDynamicMatchingTests }
+
+procedure TWebMockDynamicMatchingTests.DynamicMatcher_Always_CanBeChainedToProvideCustomResponses;
+var
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest(
+    function(ARequest: IWebMockHTTPRequest): Boolean
+    begin
+      Result := True;
+    end
+  ).ToRespond(TWebMockResponseStatus.Created);
+  LResponse := WebClient.Post(WebMock.URLFor('/resource'), TStringStream.Create(''));
+
+  Assert.AreEqual(201, LResponse.StatusCode);
+end;
+
+procedure TWebMockDynamicMatchingTests.DynamicMatcher_OnEachRequest_CanChooseToRespond;
+var
+  LCounter: Integer;
+  LResponse: IHTTPResponse;
+begin
+  LCounter := 0;
+
+  WebMock.StubRequest(
+    function(ARequest: IWebMockHTTPRequest): Boolean
+    begin
+      Inc(LCounter);
+      Result := (LCounter mod 2) = 0;
+    end
+  );
+
+  LResponse := WebClient.Get(WebMock.URLFor('/'));
+  Assert.AreEqual(501, LResponse.StatusCode);
+
+  LResponse := WebClient.Get(WebMock.URLFor('/'));
+  Assert.AreEqual(200, LResponse.StatusCode);
+end;
+
+procedure TWebMockDynamicMatchingTests.DynamicMatcher_OnEachRequest_ProvidesRequestForEvaluation;
+var
+  LRequest: IWebMockHTTPRequest;
+begin
+  WebMock.StubRequest(
+    function(ARequest: IWebMockHTTPRequest): Boolean
+    begin
+      LRequest := ARequest;
+      Result := True;
+    end
+  );
+  WebClient.Get(WebMock.URLFor('/'));
+
+  Assert.AreEqual('GET', LRequest.Method);
+  Assert.AreEqual('/', LRequest.RequestURI);
+end;
+
+procedure TWebMockDynamicMatchingTests.DynamicMatcher_ReturningFalse_RespondsNotImplemented;
+var
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest(
+    function(ARequest: IWebMockHTTPRequest): Boolean
+    begin
+      Result := False;
+    end
+  );
+  LResponse := WebClient.Get(WebMock.URLFor('/'));
+
+  Assert.AreEqual(501, LResponse.StatusCode);
+end;
+
+procedure TWebMockDynamicMatchingTests.DynamicMatcher_ReturningTrue_RespondsOK;
+var
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest(
+    function(ARequest: IWebMockHTTPRequest): Boolean
+    begin
+      Result := True;
+    end
+  );
+  LResponse := WebClient.Get(WebMock.URLFor('/'));
+
+  Assert.AreEqual(200, LResponse.StatusCode);
+end;
+
+procedure TWebMockDynamicMatchingTests.Setup;
+begin
+  WebMock := TWebMock.Create;
+end;
+
+procedure TWebMockDynamicMatchingTests.TearDown;
+begin
+  WebMock.Free;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TWebMockDynamicMatchingTests);
+end.


### PR DESCRIPTION
Resolves #22.

It is now possible to provide an anonymous predicate function to allow tests to dynamically inspect a request to decide whether to provide a response.

## Example usage:
```Delphi
WebMock.StubRequest(
  function(ARequest: IWebMockHTTPRequest): Boolean
  begin
    Result := True; // Return False to ignore request.
  end
);
```