### PR TITLE
Use fresh content streams for successive requests

### DIFF
--- a/Source/Delphi.WebMock.ResponseContentFile.pas
+++ b/Source/Delphi.WebMock.ResponseContentFile.pas
@@ -78,8 +78,12 @@ begin
 end;
 
 function TWebMockResponseContentFile.GetContentStream: TStream;
+var
+  LContentStream: TMemoryStream;
 begin
-  Result := FContentStream;
+  LContentStream := TMemoryStream.Create;
+  LContentStream.CopyFrom(FContentStream, 0);
+  Result := LContentStream;
 end;
 
 function TWebMockResponseContentFile.GetContentType: string;

--- a/Source/Delphi.WebMock.ResponseContentString.pas
+++ b/Source/Delphi.WebMock.ResponseContentString.pas
@@ -33,7 +33,6 @@ type
   TWebMockResponseContentString = class(TInterfacedObject,
     IWebMockResponseBodySource)
   private
-    FContentStream: TStream;
     FContentString: string;
     FContentType: string;
     procedure SetContentType(const Value: string);
@@ -72,10 +71,7 @@ end;
 
 function TWebMockResponseContentString.GetContentStream: TStream;
 begin
-  if not Assigned(FContentStream) then
-    FContentStream := TStringStream.Create(ContentString);
-
-  Result := FContentStream;
+  Result := TStringStream.Create(ContentString);
 end;
 
 function TWebMockResponseContentString.GetContentString: string;

--- a/Tests/Features/Delphi.WebMock.ResponsesWithBody.Tests.pas
+++ b/Tests/Features/Delphi.WebMock.ResponsesWithBody.Tests.pas
@@ -53,9 +53,13 @@ type
     [Test]
     procedure Response_WhenWithBodyIsString_ReturnsUTF8CharSet;
     [Test]
+    procedure Response_WhenWithBodyIsStringOnMultipleCalls_Succeeds;
+    [Test]
     procedure Response_WhenWithBodyFileWithoutContentType_SetsContentTypeToInferedType;
     [Test]
     procedure Response_WhenWithBodyFileWithContentType_SetsContentType;
+    [Test]
+    procedure Response_WhenWithBodyFileOnMultipleCalls_Succeeds;
   end;
 
 implementation
@@ -66,6 +70,23 @@ uses
   IdGlobal,
   System.Net.HttpClient,
   TestHelpers;
+
+procedure TWebMockResponsesWithBodyTests.Response_WhenWithBodyFileOnMultipleCalls_Succeeds;
+var
+  LExpected: string;
+  LResponse: IHTTPResponse;
+begin
+  LExpected := '{ "key": "value" }'#10;
+  WebMock.StubRequest('GET', '/json').ToRespond.WithBodyFile(FixturePath('Response.json'));
+
+  // First request
+  LResponse := WebClient.Get(WebMock.URLFor('json'));
+  Assert.AreEqual(LExpected, LResponse.ContentAsString);
+
+  // Second request
+  LResponse := WebClient.Get(WebMock.URLFor('json'));
+  Assert.AreEqual(LExpected, LResponse.ContentAsString);
+end;
 
 procedure TWebMockResponsesWithBodyTests.Response_WhenWithBodyFileWithContentType_SetsContentType;
 var
@@ -126,6 +147,23 @@ begin
 
   LContentText := ReadStringFromStream(LResponse.ContentStream);
   Assert.AreEqual(LExpectedContent, LContentText);
+end;
+
+procedure TWebMockResponsesWithBodyTests.Response_WhenWithBodyIsStringOnMultipleCalls_Succeeds;
+var
+  LContent: string;
+  LResponse: IHTTPResponse;
+begin
+  LContent := 'Some text...';
+  WebMock.StubRequest('GET', '/text').ToRespond.WithBody(LContent);
+
+  // First request
+  LResponse := WebClient.Get(WebMock.URLFor('text'));
+  Assert.EndsWith(LContent, LResponse.ContentAsString);
+
+  // Second request
+  LResponse := WebClient.Get(WebMock.URLFor('text'));
+  Assert.EndsWith(LContent, LResponse.ContentAsString);
 end;
 
 procedure TWebMockResponsesWithBodyTests.Response_WhenWithBodyIsString_ReturnsUTF8CharSet;

--- a/Tests/Fixtures/Response.json
+++ b/Tests/Fixtures/Response.json
@@ -1,3 +1,1 @@
-{
-  "key": "value"
-}
+{ "key": "value" }


### PR DESCRIPTION
Fixes #32.

Implementations of `IWebMockResponseBodySource` now return new streams
on calling `GetContentStream`. The content streams are freed by the Indy
HTTP server after completion.
