### PR TITLE
Allow any authorization header values for stubs

### DIFF
--- a/Source/Delphi.WebMock.pas
+++ b/Source/Delphi.WebMock.pas
@@ -53,6 +53,9 @@ type
     procedure StartServer(const APort: TWebWockPort);
     procedure OnServerRequest(AContext: TIdContext;
       ARequestInfo: TIdHTTPRequestInfo; AResponseInfo: TIdHTTPResponseInfo);
+    procedure AllowAnyAuth(AContext: TIdContext;
+      const AAuthType, AAuthData: String; var VUsername, VPassword: String;
+      var VHandled: Boolean);
     function GetRequestStub(ARequestInfo: IWebMockHTTPRequest) : IWebMockRequestStub;
     procedure RespondWith(AResponse: TWebMockResponse;
       AResponseInfo: TIdHTTPResponseInfo);
@@ -97,6 +100,12 @@ uses
   IdStack;
 
 { TWebMock }
+
+procedure TWebMock.AllowAnyAuth(AContext: TIdContext; const AAuthType,
+  AAuthData: String; var VUsername, VPassword: String; var VHandled: Boolean);
+begin
+  VHandled := True;
+end;
 
 function TWebMock.Assert: TWebMockAssertion;
 begin
@@ -159,6 +168,7 @@ begin
   Server.ServerSoftware := 'Delphi WebMocks';
   Server.OnCommandGet := OnServerRequest;
   Server.OnCommandOther := OnServerRequest;
+  Server.OnParseAuthentication := AllowAnyAuth;
   StartServer(APort);
 end;
 

--- a/Tests/Features/Delphi.WebMock.Responses.Tests.pas
+++ b/Tests/Features/Delphi.WebMock.Responses.Tests.pas
@@ -54,6 +54,8 @@ type
     procedure Response_WhenToRespondSetsStatus_ReturnsSpecifiedStatusText;
     [Test]
     procedure Response_WhenToRespondSetsCustomStatus_ReturnsSpecifiedStatusText;
+    [Test]
+    procedure Response_WhenRequestAuthorizationHeaderIsNotBasic_ItRespondsWithoutError;
   end;
 
 implementation
@@ -62,8 +64,23 @@ implementation
 
 uses
   Delphi.WebMock.ResponseStatus,
-  System.Net.HttpClient, System.StrUtils,
+  System.Net.HttpClient, System.Net.URLClient, System.StrUtils,
   TestHelpers;
+
+procedure TWebMockResponsesTests.Response_WhenRequestAuthorizationHeaderIsNotBasic_ItRespondsWithoutError;
+var
+  LHeaders: TNetHeaders;
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest('*', '*');
+
+  LHeaders := TNetHeaders.Create(
+    TNetHeader.Create('Authorization', 'NonStandardAuthScheme')
+  );
+  LResponse := WebClient.Get(WebMock.BaseURL, nil, LHeaders);
+
+  Assert.AreEqual(200, LResponse.StatusCode);
+end;
 
 procedure TWebMockResponsesTests.Response_WhenRequestIsNotStubbed_ReturnsNotImplemented;
 var


### PR DESCRIPTION
Fixes #34.

Removing authorization checks for request stubs allows testing of
requests with an authorization header without interference from the
default authorization behaviour. This is useful for testing custom
authorization schemes.
