### PR TITLE
Add support for dynamic responses

### DIFF
--- a/Source/WebMock.HTTP.Request.pas
+++ b/Source/WebMock.HTTP.Request.pas
@@ -2,7 +2,7 @@
 {                                                                              }
 {           Delphi-WebMocks                                                    }
 {                                                                              }
-{           Copyright (c) 2019 Richard Hatherall                               }
+{           Copyright (c) 2019-2020 Richard Hatherall                          }
 {                                                                              }
 {           richard@appercept.com                                              }
 {           https://appercept.com                                              }
@@ -28,7 +28,8 @@ unit WebMock.HTTP.Request;
 interface
 
 uses
-  IdCustomHTTPServer, IdHeaderList,
+  IdCustomHTTPServer,
+  IdHeaderList,
   System.Classes,
   WebMock.HTTP.Messages;
 

--- a/Source/WebMock.RequestStub.pas
+++ b/Source/WebMock.RequestStub.pas
@@ -29,16 +29,19 @@ interface
 
 uses
   System.Classes,
-  WebMock.HTTP.Messages, WebMock.Response;
+  System.Net.HttpClient,
+  WebMock.HTTP.Messages,
+  WebMock.Responder,
+  WebMock.Response;
 
 type
   IWebMockRequestStub = interface(IInterface)
     ['{AA474C0C-CA37-44CF-A66A-3B024CC79BE6}']
     function IsMatch(ARequest: IWebMockHTTPRequest): Boolean;
-    function GetResponse: TWebMockResponse;
-    procedure SetResponse(const AResponse: TWebMockResponse);
+    function GetResponder: IWebMockResponder;
+    procedure SetResponder(const AResponder: IWebMockResponder);
     function ToString: string;
-    property Response: TWebMockResponse read GetResponse write SetResponse;
+    property Responder: IWebMockResponder read GetResponder write SetResponder;
   end;
 
 implementation

--- a/Source/WebMock.Responder.pas
+++ b/Source/WebMock.Responder.pas
@@ -2,7 +2,7 @@
 {                                                                              }
 {           Delphi-WebMocks                                                    }
 {                                                                              }
-{           Copyright (c) 2019-2020 Richard Hatherall                          }
+{           Copyright (c) 2020 Richard Hatherall                               }
 {                                                                              }
 {           richard@appercept.com                                              }
 {           https://appercept.com                                              }
@@ -23,71 +23,20 @@
 {                                                                              }
 {******************************************************************************}
 
-unit WebMock.Response.Tests;
+unit WebMock.Responder;
 
 interface
 
 uses
-  DUnitX.TestFramework,
+  WebMock.HTTP.Messages,
   WebMock.Response;
 
 type
-  [TestFixture]
-  TWebMockResponseTests = class(TObject)
-  private
-    WebMockResponse: TWebMockResponse;
-  public
-    [Setup]
-    procedure Setup;
-    [TearDown]
-    procedure TearDown;
-    [Test]
-    procedure Create_WithoutArguments_SetsStatusToOK;
-    [Test]
-    procedure Create_WithStatus_SetsStatus;
-    [Test]
-    procedure BodySource_WhenNotSet_ReturnsEmptyContentSource;
+  IWebMockResponder = interface(IInterface)
+    ['{DC0BF955-CBFB-4EBB-987B-0A5FCE2C6575}']
+    function GetResponseTo(const ARequest: IWebMockHTTPRequest): TWebMockResponse;
   end;
 
 implementation
 
-{ TWebMockResponseTests }
-
-uses
-  TestHelpers,
-  WebMock.ResponseStatus;
-
-procedure TWebMockResponseTests.Setup;
-begin
-  WebMockResponse := TWebMockResponse.Create;
-end;
-
-procedure TWebMockResponseTests.TearDown;
-begin
-  WebMockResponse.Free;
-end;
-
-procedure TWebMockResponseTests.BodySource_WhenNotSet_ReturnsEmptyContentSource;
-begin
-  Assert.AreEqual(Int64(0), WebMockResponse.BodySource.ContentStream.Size);
-end;
-
-procedure TWebMockResponseTests.Create_WithoutArguments_SetsStatusToOK;
-begin
-  Assert.AreEqual(200, WebMockResponse.Status.Code);
-end;
-
-procedure TWebMockResponseTests.Create_WithStatus_SetsStatus;
-var
-  LExpectedStatus: TWebMockResponseStatus;
-begin
-  LExpectedStatus := TWebMockResponseStatus.Accepted;
-
-  WebMockResponse := TWebMockResponse.Create(LExpectedStatus);
-
-  Assert.AreSame(LExpectedStatus, WebMockResponse.Status);
-end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TWebMockResponseTests);
 end.

--- a/Source/WebMock.Static.Responder.pas
+++ b/Source/WebMock.Static.Responder.pas
@@ -2,7 +2,7 @@
 {                                                                              }
 {           Delphi-WebMocks                                                    }
 {                                                                              }
-{           Copyright (c) 2019-2020 Richard Hatherall                          }
+{           Copyright (c) 2020 Richard Hatherall                               }
 {                                                                              }
 {           richard@appercept.com                                              }
 {           https://appercept.com                                              }
@@ -23,71 +23,42 @@
 {                                                                              }
 {******************************************************************************}
 
-unit WebMock.Response.Tests;
+unit WebMock.Static.Responder;
 
 interface
 
 uses
-  DUnitX.TestFramework,
+  WebMock.HTTP.Messages,
+  WebMock.Responder,
   WebMock.Response;
 
 type
-  [TestFixture]
-  TWebMockResponseTests = class(TObject)
+  TWebMockStaticResponder = class(TInterfacedObject, IWebMockResponder)
   private
-    WebMockResponse: TWebMockResponse;
+    FResponse: TWebMockResponse;
   public
-    [Setup]
-    procedure Setup;
-    [TearDown]
-    procedure TearDown;
-    [Test]
-    procedure Create_WithoutArguments_SetsStatusToOK;
-    [Test]
-    procedure Create_WithStatus_SetsStatus;
-    [Test]
-    procedure BodySource_WhenNotSet_ReturnsEmptyContentSource;
+    constructor Create(const AResponse: TWebMockResponse);
+
+    { IWebMockResponder }
+    function GetResponseTo(const ARequest: IWebMockHTTPRequest): TWebMockResponse;
+
+    property Response: TWebMockResponse read FResponse;
   end;
 
 implementation
 
-{ TWebMockResponseTests }
+{ TWebMockStaticResponder }
 
-uses
-  TestHelpers,
-  WebMock.ResponseStatus;
-
-procedure TWebMockResponseTests.Setup;
+constructor TWebMockStaticResponder.Create(const AResponse: TWebMockResponse);
 begin
-  WebMockResponse := TWebMockResponse.Create;
+  inherited Create;
+  FResponse := AResponse;
 end;
 
-procedure TWebMockResponseTests.TearDown;
+function TWebMockStaticResponder.GetResponseTo(
+  const ARequest: IWebMockHTTPRequest): TWebMockResponse;
 begin
-  WebMockResponse.Free;
+  Result := FResponse;
 end;
 
-procedure TWebMockResponseTests.BodySource_WhenNotSet_ReturnsEmptyContentSource;
-begin
-  Assert.AreEqual(Int64(0), WebMockResponse.BodySource.ContentStream.Size);
-end;
-
-procedure TWebMockResponseTests.Create_WithoutArguments_SetsStatusToOK;
-begin
-  Assert.AreEqual(200, WebMockResponse.Status.Code);
-end;
-
-procedure TWebMockResponseTests.Create_WithStatus_SetsStatus;
-var
-  LExpectedStatus: TWebMockResponseStatus;
-begin
-  LExpectedStatus := TWebMockResponseStatus.Accepted;
-
-  WebMockResponse := TWebMockResponse.Create(LExpectedStatus);
-
-  Assert.AreSame(LExpectedStatus, WebMockResponse.Status);
-end;
-
-initialization
-  TDUnitX.RegisterTestFixture(TWebMockResponseTests);
 end.

--- a/Source/WebMock.pas
+++ b/Source/WebMock.pas
@@ -28,12 +28,22 @@ unit WebMock;
 interface
 
 uses
-  IdContext, IdCustomHTTPServer, IdGlobal, IdHTTPServer,
-  System.Classes, System.Generics.Collections, System.RegularExpressions,
+  IdContext,
+  IdCustomHTTPServer,
+  IdGlobal,
+  IdHTTPServer,
+  System.Classes,
+  System.Generics.Collections,
+  System.RegularExpressions,
   System.SysUtils,
-  WebMock.Assertion, WebMock.HTTP.Messages, WebMock.RequestStub,
-  WebMock.Static.RequestStub, WebMock.Dynamic.RequestStub, WebMock.Response,
-  WebMock.ResponseBodySource, WebMock.ResponseStatus;
+  WebMock.Assertion,
+  WebMock.HTTP.Messages,
+  WebMock.RequestStub,
+  WebMock.Static.RequestStub,
+  WebMock.Dynamic.RequestStub,
+  WebMock.Response,
+  WebMock.ResponseBodySource,
+  WebMock.ResponseStatus;
 
 type
   EWebMockError = class(Exception);
@@ -181,7 +191,10 @@ begin
   History.Add(LRequest);
   LRequestStub := GetRequestStub(LRequest);
   if Assigned(LRequestStub) then
-    RespondWith(LRequestStub.Response, AResponseInfo)
+    RespondWith(
+      LRequestStub.Responder.GetResponseTo(LRequest),
+      AResponseInfo
+    )
   else
     SetResponseStatus(AResponseInfo, TWebMockResponseStatus.NotImplemented);
 end;

--- a/Tests/WebMock.Dynamic.RequestStub.Tests.pas
+++ b/Tests/WebMock.Dynamic.RequestStub.Tests.pas
@@ -44,10 +44,6 @@ type
     [Test]
     procedure IsMatch_WhenInitializedWithFunctionReturningFalse_ReturnsFalse;
     [Test]
-    procedure GetResponse_Always_GetsResponse;
-    [Test]
-    procedure SetResponse_Always_SetsResponse;
-    [Test]
     procedure ToRespond_Always_ReturnsAResponseStub;
     [Test]
     procedure ToRespond_WithNoArguments_DoesNotRaiseException;
@@ -60,10 +56,13 @@ type
 implementation
 
 uses
-  Mock.Indy.HTTPRequestInfo,
   IdCustomHTTPServer,
-  WebMock.HTTP.Messages, WebMock.HTTP.Request, WebMock.RequestStub,
-  WebMock.Response, WebMock.ResponseStatus;
+  Mock.Indy.HTTPRequestInfo,
+  WebMock.HTTP.Messages,
+  WebMock.HTTP.Request,
+  WebMock.RequestStub,
+  WebMock.Response,
+  WebMock.ResponseStatus;
 
 { TWebMockDynamicRequestStubTests }
 
@@ -79,11 +78,6 @@ begin
   );
 
   Assert.Implements<IWebMockRequestStub>(LSubject);
-end;
-
-procedure TWebMockDynamicRequestStubTests.GetResponse_Always_GetsResponse;
-begin
-  Assert.IsTrue(StubbedRequest.GetResponse <> nil, 'GetResponse should return a response');
 end;
 
 procedure TWebMockDynamicRequestStubTests.IsMatch_WhenInitializedWithFunctionReturningFalse_ReturnsFalse;
@@ -122,31 +116,21 @@ begin
   Assert.IsTrue(StubbedRequest.IsMatch(LRequest));
 end;
 
-procedure TWebMockDynamicRequestStubTests.SetResponse_Always_SetsResponse;
-var
-  LResponse: TWebMockResponse;
-begin
-  LResponse := TWebMockResponse.Create;
-
-  StubbedRequest.SetResponse(LResponse);
-
-  Assert.AreSame(LResponse, StubbedRequest.Response, 'SetResponse should set Response');
-end;
-
 procedure TWebMockDynamicRequestStubTests.ToRespond_Always_ReturnsAResponseStub;
 begin
-  Assert.IsTrue(StubbedRequest.ToRespond is TWebMockResponse);
+  Assert.IsNotNull(StubbedRequest.ToRespond as IWebMockResponseBuilder);
 end;
 
 procedure TWebMockDynamicRequestStubTests.ToRespond_WithNoArguments_DoesNotChangeStatus;
 var
   LExpectedStatus: TWebMockResponseStatus;
 begin
-  LExpectedStatus := StubbedRequest.Response.Status;
+  LExpectedStatus := StubbedRequest.Responder.GetResponseTo(nil).Status;
 
   StubbedRequest.ToRespond;
 
-  Assert.AreSame(LExpectedStatus, StubbedRequest.Response.Status);
+  Assert.AreSame(LExpectedStatus,
+                 StubbedRequest.Responder.GetResponseTo(nil).Status);
 end;
 
 procedure TWebMockDynamicRequestStubTests.ToRespond_WithNoArguments_DoesNotRaiseException;

--- a/Tests/WebMock.Dynamic.Responder.Tests.pas
+++ b/Tests/WebMock.Dynamic.Responder.Tests.pas
@@ -1,0 +1,137 @@
+﻿{******************************************************************************}
+{                                                                              }
+{           Delphi-WebMocks                                                    }
+{                                                                              }
+{           Copyright (c) 2020 Richard Hatherall                               }
+{                                                                              }
+{           richard@appercept.com                                              }
+{           https://appercept.com                                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{   Licensed under the Apache License, Version 2.0 (the "License");            }
+{   you may not use this file except in compliance with the License.           }
+{   You may obtain a copy of the License at                                    }
+{                                                                              }
+{       http://www.apache.org/licenses/LICENSE-2.0                             }
+{                                                                              }
+{   Unless required by applicable law or agreed to in writing, software        }
+{   distributed under the License is distributed on an "AS IS" BASIS,          }
+{   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   }
+{   See the License for the specific language governing permissions and        }
+{   limitations under the License.                                             }
+{                                                                              }
+{******************************************************************************}
+
+unit WebMock.Dynamic.Responder.Tests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  Mock.Indy.HTTPRequestInfo,
+  WebMock.Dynamic.Responder,
+  WebMock.HTTP.Messages,
+  WebMock.HTTP.Request;
+
+type
+  [TestFixture]
+  TWebMockDynamicResponderTests = class(TObject)
+  private
+    Responder: TWebMockDynamicResponder;
+    IndyRequest: TMockIdHTTPRequestInfo;
+    Request: IWebMockHTTPRequest;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+    [Test]
+    procedure GetResponseTo_Always_ReturnsResponse;
+    [Test]
+    procedure GetResponseTo_Always_CallsProcWithRequest;
+    [Test]
+    procedure GetResponseTo_Always_CallsProcWithInitialisedResponseBuilder;
+    [Test]
+    procedure GetResponseTo_Always_ReturnsBuiltResponse;
+  end;
+
+implementation
+
+uses
+  WebMock.Response;
+
+{ TWebMockDynamicResponderTests }
+
+procedure TWebMockDynamicResponderTests.GetResponseTo_Always_CallsProcWithInitialisedResponseBuilder;
+begin
+  Responder := TWebMockDynamicResponder.Create(
+    procedure(const ARequest: IWebMockHTTPRequest; const AResponse: IWebMockResponseBuilder)
+    begin
+      Assert.IsNotNull(AResponse, 'Response builder should be initialised.');
+    end
+  );
+  Responder.GetResponseTo(Request);
+
+  Responder.Free;
+end;
+
+procedure TWebMockDynamicResponderTests.GetResponseTo_Always_CallsProcWithRequest;
+begin
+  Responder := TWebMockDynamicResponder.Create(
+    procedure(const ARequest: IWebMockHTTPRequest; const AResponse: IWebMockResponseBuilder)
+    begin
+      Assert.AreSame(Request, ARequest);
+    end
+  );
+  Responder.GetResponseTo(Request);
+
+  Responder.Free;
+end;
+
+procedure TWebMockDynamicResponderTests.GetResponseTo_Always_ReturnsBuiltResponse;
+var
+  LResponse: TWebMockResponse;
+begin
+  Responder := TWebMockDynamicResponder.Create(
+    procedure(const ARequest: IWebMockHTTPRequest; const AResponse: IWebMockResponseBuilder)
+    begin
+      AResponse.WithStatus(401);
+    end
+  );
+  LResponse := Responder.GetResponseTo(Request);
+
+  Assert.AreEqual(401, LResponse.Status.Code);
+
+  Responder.Free;
+end;
+
+procedure TWebMockDynamicResponderTests.GetResponseTo_Always_ReturnsResponse;
+begin
+  Responder := TWebMockDynamicResponder.Create(
+    procedure(const ARequest: IWebMockHTTPRequest; const AResponse: IWebMockResponseBuilder)
+    begin
+      // Do nothing.
+    end
+  );
+
+  Assert.IsNotNull(Responder.GetResponseTo(nil));
+
+  Responder.Free;
+end;
+
+procedure TWebMockDynamicResponderTests.Setup;
+begin
+  IndyRequest := TMockIdHTTPRequestInfo.Mock;
+  Request := TWebMockHTTPRequest.Create(IndyRequest);
+end;
+
+procedure TWebMockDynamicResponderTests.TearDown;
+begin
+  Request := nil;
+  IndyRequest.Free;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TWebMockDynamicResponderTests);
+end.

--- a/Tests/WebMock.HTTP.RequestMatcher.Tests.pas
+++ b/Tests/WebMock.HTTP.RequestMatcher.Tests.pas
@@ -75,9 +75,13 @@ implementation
 uses
   Mock.Indy.HTTPRequestInfo,
   TestHelpers,
-  System.Classes, System.Generics.Collections,
-  WebMock.HTTP.Messages, WebMock.HTTP.Request, WebMock.StringMatcher,
-  WebMock.StringAnyMatcher, WebMock.StringWildcardMatcher;
+  System.Classes,
+  System.Generics.Collections,
+  WebMock.HTTP.Messages,
+  WebMock.HTTP.Request,
+  WebMock.StringMatcher,
+  WebMock.StringAnyMatcher,
+  WebMock.StringWildcardMatcher;
 
 { TWebMockHTTPRequestMatcherTests }
 

--- a/Tests/WebMock.ResponseBuilder.Tests.pas
+++ b/Tests/WebMock.ResponseBuilder.Tests.pas
@@ -1,0 +1,234 @@
+﻿{******************************************************************************}
+{                                                                              }
+{           Delphi-WebMocks                                                    }
+{                                                                              }
+{           Copyright (c) 2020 Richard Hatherall                               }
+{                                                                              }
+{           richard@appercept.com                                              }
+{           https://appercept.com                                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{   Licensed under the Apache License, Version 2.0 (the "License");            }
+{   you may not use this file except in compliance with the License.           }
+{   You may obtain a copy of the License at                                    }
+{                                                                              }
+{       http://www.apache.org/licenses/LICENSE-2.0                             }
+{                                                                              }
+{   Unless required by applicable law or agreed to in writing, software        }
+{   distributed under the License is distributed on an "AS IS" BASIS,          }
+{   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   }
+{   See the License for the specific language governing permissions and        }
+{   limitations under the License.                                             }
+{                                                                              }
+{******************************************************************************}
+
+unit WebMock.ResponseBuilder.Tests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  WebMock.Response;
+
+type
+  [TestFixture]
+  TWebMockResponseBuilderTests = class(TObject)
+  private
+    Response: TWebMockResponse;
+    Builder: IWebMockResponseBuilder;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+    [Test]
+    procedure WithBody_Always_ReturnsBuilder;
+    [Test]
+    procedure WithBody_WithString_SetsResponseContent;
+    [Test]
+    procedure WithBodyFile_Always_ReturnsBuilder;
+    [Test]
+    procedure WithBodyFile_WithValidFile_SetsResponseContent;
+    [Test]
+    procedure WithHeader_Always_ReturnsBuilder;
+    [Test]
+    procedure WithHeader_Always_SetsValueForHeader;
+    [Test]
+    procedure WithHeader_Always_OverwritesExistingValues;
+    [Test]
+    procedure WithHeaders_Always_ReturnsBuilder;
+    [Test]
+    procedure WithHeaders_Always_SetsAllValues;
+    [Test]
+    procedure WithStatus_GivenStatus_ReturnsBuilder;
+    [Test]
+    procedure WithStatus_GivenStatus_SetsStatus;
+    [Test]
+    procedure WithStatus_GivenRawValues_ReturnsBuilder;
+    [Test]
+    procedure WithStatus_GivenRawValues_SetsStatusCode;
+    [Test]
+    procedure WithStatus_GivenRawValues_SetsStatusText;
+  end;
+
+implementation
+
+uses
+  System.Classes,
+  TestHelpers,
+  WebMock.ResponseStatus;
+
+{ TWebMockResponseBuilderTests }
+
+procedure TWebMockResponseBuilderTests.Setup;
+begin
+  Response := TWebMockResponse.Create;
+  Builder := Response.Builder;
+end;
+
+procedure TWebMockResponseBuilderTests.TearDown;
+begin
+  Builder := nil;
+  Response.Free;
+end;
+
+procedure TWebMockResponseBuilderTests.WithBodyFile_Always_ReturnsBuilder;
+begin
+  Assert.AreSame(Builder, Builder.WithBodyFile(FixturePath('Sample.txt')));
+end;
+
+procedure TWebMockResponseBuilderTests.WithBodyFile_WithValidFile_SetsResponseContent;
+var
+  LExpectedContent: string;
+  LActualStream: TStringStream;
+begin
+  LExpectedContent := 'Sample Text';
+
+  Builder.WithBodyFile(FixturePath('Sample.txt'));
+
+  LActualStream := TStringStream.Create;
+  LActualStream.CopyFrom(Response.BodySource.ContentStream, 0);
+  Assert.AreEqual(
+    LExpectedContent,
+    LActualStream.DataString
+  );
+end;
+
+procedure TWebMockResponseBuilderTests.WithBody_Always_ReturnsBuilder;
+begin
+  Assert.AreSame(Builder, Builder.WithBody(''));
+end;
+
+procedure TWebMockResponseBuilderTests.WithBody_WithString_SetsResponseContent;
+var
+  LExpectedContent: string;
+begin
+  LExpectedContent := 'Text Body.';
+
+  Builder.WithBody(LExpectedContent);
+
+  Assert.AreEqual(
+    LExpectedContent,
+    (Response.BodySource.ContentStream as TStringStream).DataString
+  );
+end;
+
+procedure TWebMockResponseBuilderTests.WithHeaders_Always_ReturnsBuilder;
+var
+  LHeaders: TStringList;
+begin
+  LHeaders := TStringList.Create;
+
+  Assert.AreSame(Builder, Builder.WithHeaders(LHeaders));
+
+  LHeaders.Free;
+end;
+
+procedure TWebMockResponseBuilderTests.WithHeaders_Always_SetsAllValues;
+var
+  LHeaders: TStringList;
+  LHeaderName, LHeaderValue: string;
+  I: Integer;
+begin
+  LHeaders := TStringList.Create;
+  LHeaders.Values['Header1'] := 'Value1';
+  LHeaders.Values['Header2'] := 'Value2';
+
+  Builder.WithHeaders(LHeaders);
+
+  for I := 0 to LHeaders.Count - 1 do
+  begin
+    LHeaderName := LHeaders.Names[I];
+    LHeaderValue := LHeaders.ValueFromIndex[I];
+    Assert.AreEqual(LHeaderValue, Response.Headers.Values[LHeaderName]);
+  end;
+
+  LHeaders.Free;
+end;
+
+procedure TWebMockResponseBuilderTests.WithHeader_Always_OverwritesExistingValues;
+var
+  LHeaderName, LHeaderValue1, LHeaderValue2: string;
+begin
+  LHeaderName := 'Header1';
+  LHeaderValue1 := 'Value1';
+  LHeaderValue2 := 'Value2';
+
+  Builder.WithHeader(LHeaderName, LHeaderValue1);
+  Builder.WithHeader(LHeaderName, LHeaderValue2);
+
+  Assert.AreEqual(LHeaderValue2, Response.Headers.Values[LHeaderName]);
+end;
+
+procedure TWebMockResponseBuilderTests.WithHeader_Always_ReturnsBuilder;
+begin
+  Assert.AreSame(Builder, Builder.WithHeader('Header1', 'Value1'));
+end;
+
+procedure TWebMockResponseBuilderTests.WithHeader_Always_SetsValueForHeader;
+var
+  LHeaderName, LHeaderValue: string;
+begin
+  LHeaderName := 'Header1';
+  LHeaderValue := 'Value1';
+
+  Builder.WithHeader(LHeaderName, LHeaderValue);
+
+  Assert.AreEqual(LHeaderValue, Response.Headers.Values[LHeaderName]);
+end;
+
+procedure TWebMockResponseBuilderTests.WithStatus_GivenRawValues_ReturnsBuilder;
+begin
+  Assert.AreSame(Builder, Builder.WithStatus(555, 'Custom Status'));
+end;
+
+procedure TWebMockResponseBuilderTests.WithStatus_GivenRawValues_SetsStatusCode;
+begin
+  Builder.WithStatus(401);
+
+  Assert.AreEqual(401, Response.Status.Code);
+end;
+
+procedure TWebMockResponseBuilderTests.WithStatus_GivenRawValues_SetsStatusText;
+begin
+  Builder.WithStatus(555, 'Custom Status');
+
+  Assert.AreEqual('Custom Status', Response.Status.Text);
+end;
+
+procedure TWebMockResponseBuilderTests.WithStatus_GivenStatus_ReturnsBuilder;
+begin
+  Assert.AreSame(Builder, Builder.WithStatus(TWebMockResponseStatus.InternalServerError));
+end;
+
+procedure TWebMockResponseBuilderTests.WithStatus_GivenStatus_SetsStatus;
+begin
+  Builder.WithStatus(TWebMockResponseStatus.InternalServerError);
+
+  Assert.AreEqual(500, Response.Status.Code);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TWebMockResponseBuilderTests);
+end.

--- a/Tests/WebMock.Static.RequestStub.Tests.pas
+++ b/Tests/WebMock.Static.RequestStub.Tests.pas
@@ -2,7 +2,7 @@
 {                                                                              }
 {           Delphi-WebMocks                                                    }
 {                                                                              }
-{           Copyright (c) 2019 Richard Hatherall                               }
+{           Copyright (c) 2019-2020 Richard Hatherall                          }
 {                                                                              }
 {           richard@appercept.com                                              }
 {           https://appercept.com                                              }
@@ -81,9 +81,14 @@ implementation
 uses
   IdCustomHTTPServer,
   Mock.Indy.HTTPRequestInfo,
-  System.Classes, System.RegularExpressions,
-  WebMock.HTTP.RequestMatcher, WebMock.RequestStub, WebMock.Response,
-  WebMock.ResponseStatus, WebMock.StringMatcher, WebMock.StringWildcardMatcher,
+  System.Classes,
+  System.RegularExpressions,
+  WebMock.HTTP.RequestMatcher,
+  WebMock.RequestStub,
+  WebMock.Response,
+  WebMock.ResponseStatus,
+  WebMock.StringMatcher,
+  WebMock.StringWildcardMatcher,
   WebMock.StringRegExMatcher;
 
 { TWebMockRequestStubTests }
@@ -112,7 +117,7 @@ end;
 
 procedure TWebMockStaticRequestStubTests.ToRespond_Always_ReturnsAResponseStub;
 begin
-  Assert.IsTrue(StubbedRequest.ToRespond is TWebMockResponse);
+  Assert.IsNotNull(StubbedRequest.ToRespond as IWebMockResponseBuilder);
 end;
 
 procedure TWebMockStaticRequestStubTests.ToRespond_WithNoArguments_DoesNotRaiseException;
@@ -128,11 +133,12 @@ procedure TWebMockStaticRequestStubTests.ToRespond_WithNoArguments_DoesNotChange
 var
   LExpectedStatus: TWebMockResponseStatus;
 begin
-  LExpectedStatus := StubbedRequest.Response.Status;
+  LExpectedStatus := StubbedRequest.Responder.GetResponseTo(nil).Status;
 
   StubbedRequest.ToRespond;
 
-  Assert.AreSame(LExpectedStatus, StubbedRequest.Response.Status);
+  Assert.AreSame(LExpectedStatus,
+                 StubbedRequest.Responder.GetResponseTo(nil).Status);
 end;
 
 procedure TWebMockStaticRequestStubTests.ToRespond_WithResponse_SetsResponseStatus;
@@ -143,7 +149,7 @@ begin
 
   StubbedRequest.ToRespond(LResponse);
 
-  Assert.AreSame(LResponse, StubbedRequest.Response.Status);
+  Assert.AreSame(LResponse, StubbedRequest.Responder.GetResponseTo(nil).Status);
 end;
 
 procedure TWebMockStaticRequestStubTests.WithBody_GivenRegEx_ReturnsSelf;

--- a/Tests/WebMock.Static.Responder.Tests.pas
+++ b/Tests/WebMock.Static.Responder.Tests.pas
@@ -2,7 +2,7 @@
 {                                                                              }
 {           Delphi-WebMocks                                                    }
 {                                                                              }
-{           Copyright (c) 2019-2020 Richard Hatherall                          }
+{           Copyright (c) 2020 Richard Hatherall                               }
 {                                                                              }
 {           richard@appercept.com                                              }
 {           https://appercept.com                                              }
@@ -23,71 +23,43 @@
 {                                                                              }
 {******************************************************************************}
 
-unit WebMock.Response.Tests;
+unit WebMock.Static.Responder.Tests;
 
 interface
 
 uses
   DUnitX.TestFramework,
-  WebMock.Response;
+  WebMock.Static.Responder;
 
 type
   [TestFixture]
-  TWebMockResponseTests = class(TObject)
+  TWebMockStaticResponderTests = class(TObject)
   private
-    WebMockResponse: TWebMockResponse;
+    Responder: TWebMockStaticResponder;
   public
-    [Setup]
-    procedure Setup;
-    [TearDown]
-    procedure TearDown;
     [Test]
-    procedure Create_WithoutArguments_SetsStatusToOK;
-    [Test]
-    procedure Create_WithStatus_SetsStatus;
-    [Test]
-    procedure BodySource_WhenNotSet_ReturnsEmptyContentSource;
+    procedure GetResponseTo_Always_ReturnsResponse;
   end;
 
 implementation
 
-{ TWebMockResponseTests }
-
 uses
-  TestHelpers,
-  WebMock.ResponseStatus;
+  WebMock.Response;
 
-procedure TWebMockResponseTests.Setup;
-begin
-  WebMockResponse := TWebMockResponse.Create;
-end;
+{ TWebMockStaticResponderTests }
 
-procedure TWebMockResponseTests.TearDown;
-begin
-  WebMockResponse.Free;
-end;
-
-procedure TWebMockResponseTests.BodySource_WhenNotSet_ReturnsEmptyContentSource;
-begin
-  Assert.AreEqual(Int64(0), WebMockResponse.BodySource.ContentStream.Size);
-end;
-
-procedure TWebMockResponseTests.Create_WithoutArguments_SetsStatusToOK;
-begin
-  Assert.AreEqual(200, WebMockResponse.Status.Code);
-end;
-
-procedure TWebMockResponseTests.Create_WithStatus_SetsStatus;
+procedure TWebMockStaticResponderTests.GetResponseTo_Always_ReturnsResponse;
 var
-  LExpectedStatus: TWebMockResponseStatus;
+  LResponse: TWebMockResponse;
 begin
-  LExpectedStatus := TWebMockResponseStatus.Accepted;
+  LResponse := TWebMockResponse.Create;
+  Responder := TWebMockStaticResponder.Create(LResponse);
 
-  WebMockResponse := TWebMockResponse.Create(LExpectedStatus);
+  Assert.AreSame(LResponse, Responder.GetResponseTo(nil) as TWebMockResponse);
 
-  Assert.AreSame(LExpectedStatus, WebMockResponse.Status);
+  Responder.Free;
 end;
 
 initialization
-  TDUnitX.RegisterTestFixture(TWebMockResponseTests);
+  TDUnitX.RegisterTestFixture(TWebMockStaticResponderTests);
 end.

--- a/Tests/WebMocks.Tests.dpr
+++ b/Tests/WebMocks.Tests.dpr
@@ -53,7 +53,14 @@ uses
   WebMock.DynamicMatching.Tests in 'Features\WebMock.DynamicMatching.Tests.pas',
   WebMock.Dynamic.RequestStub.Tests in 'WebMock.Dynamic.RequestStub.Tests.pas',
   WebMock.Dynamic.RequestStub in '..\Source\WebMock.Dynamic.RequestStub.pas',
-  WebMock.RequestStub in '..\Source\WebMock.RequestStub.pas';
+  WebMock.RequestStub in '..\Source\WebMock.RequestStub.pas',
+  WebMock.Static.Responder.Tests in 'WebMock.Static.Responder.Tests.pas',
+  WebMock.Static.Responder in '..\Source\WebMock.Static.Responder.pas',
+  WebMock.Responder in '..\Source\WebMock.Responder.pas',
+  WebMock.ResponseBuilder.Tests in 'WebMock.ResponseBuilder.Tests.pas',
+  WebMock.DynamicResponses.Tests in 'Features\WebMock.DynamicResponses.Tests.pas',
+  WebMock.Dynamic.Responder.Tests in 'WebMock.Dynamic.Responder.Tests.pas',
+  WebMock.Dynamic.Responder in '..\Source\WebMock.Dynamic.Responder.pas';
 
 var
   Runner: ITestRunner;

--- a/Tests/WebMocks.Tests.dproj
+++ b/Tests/WebMocks.Tests.dproj
@@ -186,6 +186,13 @@
         <DCCReference Include="WebMock.Dynamic.RequestStub.Tests.pas"/>
         <DCCReference Include="..\Source\WebMock.Dynamic.RequestStub.pas"/>
         <DCCReference Include="..\Source\WebMock.RequestStub.pas"/>
+        <DCCReference Include="WebMock.Static.Responder.Tests.pas"/>
+        <DCCReference Include="..\Source\WebMock.Static.Responder.pas"/>
+        <DCCReference Include="..\Source\WebMock.Responder.pas"/>
+        <DCCReference Include="WebMock.ResponseBuilder.Tests.pas"/>
+        <DCCReference Include="Features\WebMock.DynamicResponses.Tests.pas"/>
+        <DCCReference Include="WebMock.Dynamic.Responder.Tests.pas"/>
+        <DCCReference Include="..\Source\WebMock.Dynamic.Responder.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -245,6 +252,12 @@
                 <DeployFile LocalName="WebMocks.Tests.info.plist" Configuration="Debug" Class="ProjectOSXInfoPList">
                     <Platform Name="OSX64">
                         <RemoteName>Info.plist</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="WebMocks.Tests.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>WebMocks_Tests.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>


### PR DESCRIPTION
Resolves #16.

It is now possible to create responses dynamically. This enables greater
customisation on a per-request basis. For example:

```Delphi
WebMock.StubRequest('*', '*')
  .ToRespondWith(
    procedure (const ARequest: IWebMockHTTPRequest;
               const AResponse: IWebMockResponseBuilder)
    begin
      AReponse
        .WithStatus(202)
        .WithHeader('header-1', 'a-value')
        .WithBody('Some content...');
    end
  );
```

The `ARequest: IWebMockHTTPRequest` parameter is available for
inspection.

The internals have been updated to introduce a "responder" layer
allowing different handlers for responses which should be useful beyond
this change.
