### PR TITLE
Bind to localhost only

### DIFF
--- a/Source/WebMock.pas
+++ b/Source/WebMock.pas
@@ -282,6 +282,7 @@ begin
       LPort := GetNextPort;
     Server.Bindings.Clear;
     LSocketHandle := Server.Bindings.Add;
+    LSocketHandle.IP := '127.0.0.1';
     LSocketHandle.Port := LPort;
     try
       Server.Active := True;


### PR DESCRIPTION
Fixes #44.

Binding to localhost only instead of "any" avoids triggering the
Windows Developer Firewall prompt.
