### PR TITLE
Add support for matching requests by query params

### DIFF
--- a/Source/WebMock.Static.RequestStub.pas
+++ b/Source/WebMock.Static.RequestStub.pas
@@ -66,6 +66,8 @@ type
     function WithJSON(const APath: string; const AValue: Float64): TWebMockStaticRequestStub; overload;
     function WithJSON(const APath: string; const AValue: Integer): TWebMockStaticRequestStub; overload;
     function WithJSON(const APath: string; const AValue: string): TWebMockStaticRequestStub; overload;
+    function WithQueryParam(const AName, AValue: string): TWebMockStaticRequestStub; overload;
+    function WithQueryParam(const AName: string; const APattern: TRegEx): TWebMockStaticRequestStub; overload;
 
     // IWebMockRequestStub
     function IsMatch(ARequest: IWebMockHTTPRequest): Boolean;
@@ -241,6 +243,28 @@ begin
     Matcher.Body := TWebMockJSONMatcher.Create;
 
   (Matcher.Body as TWebMockJSONMatcher).Add<string>(APath, AValue);
+
+  Result := Self;
+end;
+
+function TWebMockStaticRequestStub.WithQueryParam(const AName: string;
+  const APattern: TRegEx): TWebMockStaticRequestStub;
+begin
+  Matcher.QueryParams.AddOrSetValue(
+    AName,
+    TWebMockStringRegExMatcher.Create(APattern)
+  );
+
+  Result := Self;
+end;
+
+function TWebMockStaticRequestStub.WithQueryParam(const AName,
+  AValue: string): TWebMockStaticRequestStub;
+begin
+  Matcher.QueryParams.AddOrSetValue(
+    AName,
+    TWebMockStringWildcardMatcher.Create(AValue)
+  );
 
   Result := Self;
 end;

--- a/Tests/Features/WebMock.Matching.Tests.pas
+++ b/Tests/Features/WebMock.Matching.Tests.pas
@@ -62,6 +62,14 @@ type
     [TestCase('No Resource by ID', 'GET,^/resource/\d+$,resource/abc')]
     procedure RequestWithMethodAndRegExPath_NotMatching_RespondsNotImplemented(const AMatcherMethod, AMatcherURIPattern, ARequestURI: string);
     [Test]
+    procedure Request_MatchingQueryParam_RespondsOK;
+    [Test]
+    procedure Request_NotMatchingQueryParam_RespondsNotImplemented;
+    [Test]
+    procedure Request_MatchingQueryParamByRegEx_RespondsOK;
+    [Test]
+    procedure Request_NotMatchingQueryParamByRegEx_RespondsNotImplemented;
+    [Test]
     procedure Request_MatchingSingleHeader_RespondsOK;
     [Test]
     procedure Request_NotMatchingSingleHeader_RespondsNotImplemented;
@@ -133,6 +141,26 @@ begin
   Assert.AreEqual(200, LResponse.StatusCode);
 end;
 
+procedure TWebMockMatchingTests.Request_MatchingQueryParamByRegEx_RespondsOK;
+var
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest('*', '*').WithQueryParam('Param1', TRegEx.Create('Value\d'));
+  LResponse := WebClient.Get(WebMock.URLFor('/endpoint?Param1=Value1'));
+
+  Assert.AreEqual(200, LResponse.StatusCode);
+end;
+
+procedure TWebMockMatchingTests.Request_MatchingQueryParam_RespondsOK;
+var
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest('*', '*').WithQueryParam('Param1', 'Value1');
+  LResponse := WebClient.Get(WebMock.URLFor('/endpoint?Param1=Value1'));
+
+  Assert.AreEqual(200, LResponse.StatusCode);
+end;
+
 procedure TWebMockMatchingTests.Request_MatchingSingleHeaderByRegEx_RespondsOK;
 var
   LHeaderName: string;
@@ -175,6 +203,26 @@ var
 begin
   WebMock.StubRequest(AMatcherMethod, AMatcherURI);
   LResponse := WebClient.Get(WebMock.URLFor(ARequestURI));
+
+  Assert.AreEqual(501, LResponse.StatusCode);
+end;
+
+procedure TWebMockMatchingTests.Request_NotMatchingQueryParamByRegEx_RespondsNotImplemented;
+var
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest('*', '*').WithQueryParam('Param1', TRegEx.Create('Value\d'));
+  LResponse := WebClient.Get(WebMock.URLFor('/endpoint?Param1=ValueA'));
+
+  Assert.AreEqual(501, LResponse.StatusCode);
+end;
+
+procedure TWebMockMatchingTests.Request_NotMatchingQueryParam_RespondsNotImplemented;
+var
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest('*', '*').WithQueryParam('Param1', 'Value1');
+  LResponse := WebClient.Get(WebMock.URLFor('/endpoint?Param1=Value2'));
 
   Assert.AreEqual(501, LResponse.StatusCode);
 end;

--- a/Tests/WebMock.Static.RequestStub.Tests.pas
+++ b/Tests/WebMock.Static.RequestStub.Tests.pas
@@ -98,6 +98,14 @@ type
     procedure WithJSON_GivenPathAndString_ReturnsSelf;
     [Test]
     procedure WithJSON_GivenPathAndString_SetsMatcherForContent;
+    [Test]
+    procedure WithQueryParam_GivenString_ReturnsSelf;
+    [Test]
+    procedure WithQueryParam_GivenString_SetsMatcherForParam;
+    [Test]
+    procedure WithQueryParam_GivenRegEx_ReturnsSelf;
+    [Test]
+    procedure WithQueryParam_GivenRegEx_SetsMatcherForParam;
   end;
 
 implementation
@@ -406,6 +414,50 @@ begin
   StubbedRequest.WithJSON('key', 'value');
 
   Assert.IsTrue(StubbedRequest.Matcher.Body is TWebMockJSONMatcher);
+end;
+
+procedure TWebMockStaticRequestStubTests.WithQueryParam_GivenRegEx_ReturnsSelf;
+begin
+  Assert.AreSame(
+    StubbedRequest,
+    StubbedRequest.WithQueryParam('name', TRegEx.Create('pattern'))
+  );
+end;
+
+procedure TWebMockStaticRequestStubTests.WithQueryParam_GivenRegEx_SetsMatcherForParam;
+var
+  LParamName: string;
+  LParamPattern: TRegEx;
+begin
+  LParamName := 'Header2';
+  LParamPattern := TRegEx.Create('');
+
+  StubbedRequest.WithQueryParam(LParamName, LParamPattern);
+
+  Assert.AreEqual(
+    LParamPattern,
+    (StubbedRequest.Matcher.QueryParams[LParamName] as TWebMockStringRegExMatcher).RegEx
+  );
+end;
+
+procedure TWebMockStaticRequestStubTests.WithQueryParam_GivenString_ReturnsSelf;
+begin
+  Assert.AreSame(StubbedRequest, StubbedRequest.WithQueryParam('name', 'value'));
+end;
+
+procedure TWebMockStaticRequestStubTests.WithQueryParam_GivenString_SetsMatcherForParam;
+var
+  LParamName, LParamValue: string;
+begin
+  LParamName := 'Name1';
+  LParamValue := 'Value1';
+
+  StubbedRequest.WithQueryParam(LParamName, LParamValue);
+
+  Assert.AreEqual(
+    LParamValue,
+    (StubbedRequest.Matcher.QueryParams[LParamName] as TWebMockStringWildcardMatcher).Value
+  );
 end;
 
 initialization

--- a/Tests/WebMocks.Tests.dproj
+++ b/Tests/WebMocks.Tests.dproj
@@ -7,7 +7,7 @@
         <TargetedPlatforms>5251</TargetedPlatforms>
         <AppType>Console</AppType>
         <FrameworkType>None</FrameworkType>
-        <ProjectVersion>19.1</ProjectVersion>
+        <ProjectVersion>19.2</ProjectVersion>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">


### PR DESCRIPTION
It is now possible to match requests by query parameters. For example:
```Delphi
WebMock.StubRequest('*', '*')
  .WithQueryParam('Action', 'DoSomething');
```

As with other matchers, regular expressions can also be used.

This matcher already exists on the `Assert` interface. This change adds
it to request stubbing for interface consistency.