### PR TITLE
Add support for asserting HEAD requests

### DIFF
--- a/Source/WebMock.Assertion.pas
+++ b/Source/WebMock.Assertion.pas
@@ -36,6 +36,7 @@ uses
   WebMock.HTTP.RequestMatcher;
 
 type
+
   TWebMockAssertion = class(TObject)
   private
     FMatcher: IWebMockHTTPRequestMatcher;
@@ -45,6 +46,7 @@ type
     constructor Create(const AHistory: IInterfaceList);
     function Delete(const AURI: string): TWebMockAssertion;
     function Get(const AURI: string): TWebMockAssertion;
+    function Head(const AURI: string): TWebMockAssertion;
     function Patch(const AURI: string): TWebMockAssertion;
     function Post(const AURI: string): TWebMockAssertion;
     function Put(const AURI: string): TWebMockAssertion;
@@ -93,6 +95,11 @@ end;
 function TWebMockAssertion.Get(const AURI: string): TWebMockAssertion;
 begin
   Result := Request('GET', AURI);
+end;
+
+function TWebMockAssertion.Head(const AURI: string): TWebMockAssertion;
+begin
+  Result := Request('HEAD', AURI);
 end;
 
 function TWebMockAssertion.MatchesHistory: Boolean;

--- a/Tests/Features/WebMock.Assertions.Tests.pas
+++ b/Tests/Features/WebMock.Assertions.Tests.pas
@@ -92,6 +92,10 @@ type
     [Test]
     procedure GetWasRequested_NotMatchingRequest_Fails;
     [Test]
+    procedure HeadWasRequested_MatchingRequest_Passes;
+    [Test]
+    procedure HeadWasRequested_NotMatchingRequest_Fails;
+    [Test]
     procedure PatchWasRequested_MatchingRequest_Passes;
     [Test]
     procedure PatchWasRequested_NotMatchingRequest_Fails;
@@ -166,6 +170,32 @@ begin
     procedure
     begin
       WebMock.Assert.Get('/resource').WasRequested;
+    end,
+    ETestFailure
+  );
+end;
+
+procedure TWebMockAssertionsTests.HeadWasRequested_MatchingRequest_Passes;
+begin
+  WebClient.Head(WebMock.URLFor('/'));
+
+  Assert.WillRaise(
+    procedure
+    begin
+      WebMock.Assert.Head('/').WasRequested;
+    end,
+    ETestPass
+  );
+end;
+
+procedure TWebMockAssertionsTests.HeadWasRequested_NotMatchingRequest_Fails;
+begin
+  WebClient.Head(WebMock.URLFor('/'));
+
+  Assert.WillRaise(
+    procedure
+    begin
+      WebMock.Assert.Head('/resource').WasRequested;
     end,
     ETestFailure
   );

--- a/Tests/WebMock.Assertion.Tests.pas
+++ b/Tests/WebMock.Assertion.Tests.pas
@@ -66,6 +66,10 @@ type
     [Test]
     procedure Get_Always_ReturnsSelf;
     [Test]
+    procedure Head_GivenMethodAndURI_SetsMatcherValues;
+    [Test]
+    procedure Head_Always_ReturnsSelf;
+    [Test]
     procedure Patch_GivenMethodAndURI_SetsMatcherValues;
     [Test]
     procedure Patch_Always_ReturnsSelf;
@@ -195,6 +199,26 @@ begin
   Assertion.Get(LURI);
 
   Assert.IsMatch('GET\s/resource', Assertion.Matcher.ToString);
+
+  Assertion.Free;
+end;
+
+procedure TWebMockAssertionTests.Head_Always_ReturnsSelf;
+begin
+  Assert.AreSame(Assertion, Assertion.Head('/'));
+
+  Assertion.Free;
+end;
+
+procedure TWebMockAssertionTests.Head_GivenMethodAndURI_SetsMatcherValues;
+var
+  LURI: string;
+begin
+  LURI := '/resource';
+
+  Assertion.Head(LURI);
+
+  Assert.IsMatch('HEAD\s/resource', Assertion.Matcher.ToString);
 
   Assertion.Free;
 end;


### PR DESCRIPTION
Resolves #47.

It is now possible to assert HEAD requests. For example:
```Delphi
WebMock.Assert.Head('/').WasRequested;
```