### PR TITLE
Add support for matching content by XML values

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,25 @@ The first argument can be a path. For example, in the following JSON, the path
 }
 ```
 
+#### Request matching by XML
+HTTP request can be matched by XML data values submitted. For example:
+```Delphi
+WebMock.StubRequest('*', '*')
+  .WithXML('/Object/Attr1', 'Value 1');
+```
+
+The first argument is an XPath expression. The previous example would make a
+positive match against the following document:
+```XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Object>
+  <Attr1>Value 1</Attr1>
+</Object>
+```
+
+The second argument can be a boolean, floating point, integer, or string
+value.
+
 #### Request matching by predicate function
 If matching logic is required to be more complex than the simple matching, a
 predicate function can be provided in the test to allow custom inspection/logic
@@ -436,7 +455,7 @@ WebMock.Assert.Get('/').WasRequested; // Passes
 ```
 
 As with request stubbing you can match requests by HTTP Method, URI, Query
-Parameters, Headers, and Body content (including `WithJSON`).
+Parameters, Headers, and Body content (including `WithJSON` and `WithXML`).
 ```Delphi
 WebMock.Assert
   .Patch('/resource`)

--- a/Source/WebMock.Assertion.pas
+++ b/Source/WebMock.Assertion.pas
@@ -65,6 +65,8 @@ type
     function WithJSON(const APath: string; AValue: Float64): TWebMockAssertion; overload;
     function WithJSON(const APath: string; AValue: Integer): TWebMockAssertion; overload;
     function WithJSON(const APath: string; AValue: string): TWebMockAssertion; overload;
+    function WithXML(const AXPath, AValue: string): TWebMockAssertion; overload;
+    function WithXML(const AXPath: string; APattern: TRegEx): TWebMockAssertion; overload;
     procedure WasRequested;
     procedure WasNotRequested;
     property History: IInterfaceList read FHistory;
@@ -267,6 +269,22 @@ function TWebMockAssertion.WithQueryParam(const AName: string;
   const APattern: TRegEx): TWebMockAssertion;
 begin
   Matcher.Builder.WithQueryParam(AName, APattern);
+
+  Result := Self;
+end;
+
+function TWebMockAssertion.WithXML(const AXPath: string;
+  APattern: TRegEx): TWebMockAssertion;
+begin
+  Matcher.Builder.WithXML(AXPath, APattern);
+
+  Result := Self;
+end;
+
+function TWebMockAssertion.WithXML(const AXPath,
+  AValue: string): TWebMockAssertion;
+begin
+  Matcher.Builder.WithXML(AXPath, AValue);
 
   Result := Self;
 end;

--- a/Source/WebMock.HTTP.RequestMatcher.pas
+++ b/Source/WebMock.HTTP.RequestMatcher.pas
@@ -63,6 +63,8 @@ type
     function WithJSON(const APath: string; AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
     function WithQueryParam(const AName, AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
     function WithQueryParam(const AName: string; const APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder; overload;
+    function WithXML(const AName, AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
+    function WithXML(const AName: string; const APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder; overload;
   end;
 
   TWebMockHTTPRequestMatcher = class(TInterfacedObject,
@@ -90,6 +92,8 @@ type
       function WithJSON(const APath: string; AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
       function WithQueryParam(const AName, AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
       function WithQueryParam(const AName: string; const APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder; overload;
+      function WithXML(const AXPath, AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
+      function WithXML(const AXPath: string; const APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder; overload;
     end;
 
   private
@@ -130,7 +134,8 @@ uses
   WebMock.JSONMatcher,
   WebMock.StringWildcardMatcher,
   WebMock.StringAnyMatcher,
-  WebMock.StringRegExMatcher;
+  WebMock.StringRegExMatcher,
+  WebMock.XMLMatcher;
 
 { TWebMockHTTPRequestMatcher }
 
@@ -429,6 +434,28 @@ begin
     AName,
     TWebMockStringRegExMatcher.Create(APattern)
   );
+
+  Result := Self;
+end;
+
+function TWebMockHTTPRequestMatcher.TBuilder.WithXML(const AXPath: string;
+  const APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder;
+begin
+  if not (Matcher.Body is TWebMockXMLMatcher) then
+    Matcher.Body := TWebMockXMLMatcher.Create;
+
+  (Matcher.Body as TWebMockXMLMatcher).Add(AXPath, APattern);
+
+  Result := Self;
+end;
+
+function TWebMockHTTPRequestMatcher.TBuilder.WithXML(const AXPath,
+  AValue: string): IWebMockHTTPRequestMatcherBuilder;
+begin
+  if not (Matcher.Body is TWebMockXMLMatcher) then
+    Matcher.Body := TWebMockXMLMatcher.Create;
+
+  (Matcher.Body as TWebMockXMLMatcher).Add(AXPath, AValue);
 
   Result := Self;
 end;

--- a/Source/WebMock.Static.RequestStub.pas
+++ b/Source/WebMock.Static.RequestStub.pas
@@ -68,6 +68,8 @@ type
     function WithJSON(const APath: string; const AValue: string): TWebMockStaticRequestStub; overload;
     function WithQueryParam(const AName, AValue: string): TWebMockStaticRequestStub; overload;
     function WithQueryParam(const AName: string; const APattern: TRegEx): TWebMockStaticRequestStub; overload;
+    function WithXML(const AXPath, AValue: string): TWebMockStaticRequestStub; overload;
+    function WithXML(const AXPath: string; const APattern: TRegEx): TWebMockStaticRequestStub; overload;
 
     // IWebMockRequestStub
     function IsMatch(ARequest: IWebMockHTTPRequest): Boolean;
@@ -87,7 +89,8 @@ uses
   WebMock.JSONMatcher,
   WebMock.Static.Responder,
   WebMock.StringWildcardMatcher,
-  WebMock.StringRegExMatcher;
+  WebMock.StringRegExMatcher,
+  WebMock.XMLMatcher;
 
 { TWebMockRequestStub }
 
@@ -100,7 +103,6 @@ begin
 end;
 
 destructor TWebMockStaticRequestStub.Destroy;
-
 begin
   Matcher.Free;
   inherited;
@@ -254,6 +256,28 @@ begin
     AName,
     TWebMockStringRegExMatcher.Create(APattern)
   );
+
+  Result := Self;
+end;
+
+function TWebMockStaticRequestStub.WithXML(const AXPath: string;
+  const APattern: TRegEx): TWebMockStaticRequestStub;
+begin
+  if not (Matcher.Body is TWebMockXMLMatcher) then
+    Matcher.Body := TWebMockXMLMatcher.Create;
+
+  (Matcher.Body as TWebMockXMLMatcher).Add(AXPath, APattern);
+
+  Result := Self;
+end;
+
+function TWebMockStaticRequestStub.WithXML(const AXPath,
+  AValue: string): TWebMockStaticRequestStub;
+begin
+  if not (Matcher.Body is TWebMockXMLMatcher) then
+    Matcher.Body := TWebMockXMLMatcher.Create;
+
+  (Matcher.Body as TWebMockXMLMatcher).Add(AXPath, AValue);
 
   Result := Self;
 end;

--- a/Source/WebMock.XMLMatcher.pas
+++ b/Source/WebMock.XMLMatcher.pas
@@ -1,0 +1,143 @@
+﻿unit WebMock.XMLMatcher;
+
+interface
+
+uses
+  System.Generics.Collections,
+  System.RegularExpressions,
+  WebMock.StringMatcher,
+  Xml.xmldom,
+  Xml.XMLIntf;
+
+type
+
+  IWebMockXMLValueMatcher = interface(IInterface)
+    ['{98312A88-8A99-45AE-9189-2A9C69CBF2FA}']
+    function IsMatch(const ANode: IDOMDocument): Boolean;
+  end;
+
+  TWebMockXMLValueMatcher = class(TInterfacedObject, IWebMockXMLValueMatcher)
+  private
+    FXPath: string;
+    FValueMatcher: IStringMatcher;
+  public
+    constructor Create(const AXPath, AValue: string); overload;
+    constructor Create(const AXPath: string; APattern: TRegEx); overload;
+    property XPath: string read FXPath;
+    property ValueMatcher: IStringMatcher read FValueMatcher;
+
+    { IWebMockXMLValueMatcher }
+    function IsMatch(const ADocument: IDOMDocument): Boolean;
+  end;
+
+  TWebMockXMLMatcher = class(TInterfacedObject, IStringMatcher)
+  private
+    FValueMatchers: TList<IWebMockXMLValueMatcher>;
+    function GetValueMatchers: TList<IWebMockXMLValueMatcher>;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    procedure Add(const AXPath, AValue: string); overload;
+    procedure Add(const AXPath: string; const APattern: TRegEx); overload;
+    property ValueMatchers: TList<IWebMockXMLValueMatcher> read GetValueMatchers;
+
+    { IStringMatcher }
+    function IsMatch(AValue: string): Boolean;
+    function ToString: string; override;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  WebMock.StringRegExMatcher,
+  WebMock.StringWildcardMatcher,
+  Xml.XMLDoc,
+  Xml.omnixmldom;
+
+{ TWebMockXMLMatcher }
+
+procedure TWebMockXMLMatcher.Add(const AXPath, AValue: string);
+begin
+  ValueMatchers.Add(TWebMockXMLValueMatcher.Create(AXPath, AValue));
+end;
+
+procedure TWebMockXMLMatcher.Add(const AXPath: string; const APattern: TRegEx);
+begin
+  ValueMatchers.Add(TWebMockXMLValueMatcher.Create(AXPath, APattern));
+end;
+
+constructor TWebMockXMLMatcher.Create;
+begin
+  inherited;
+  FValueMatchers := TList<IWebMockXMLValueMatcher>.Create;
+end;
+
+destructor TWebMockXMLMatcher.Destroy;
+begin
+  FValueMatchers.Free;
+  inherited;
+end;
+
+function TWebMockXMLMatcher.GetValueMatchers: TList<IWebMockXMLValueMatcher>;
+begin
+  Result := FValueMatchers;
+end;
+
+function TWebMockXMLMatcher.IsMatch(AValue: string): Boolean;
+var
+  XMLDoc: IXMLDocument;
+  LMatcher: IWebMockXMLValueMatcher;
+begin
+  DefaultDOMVendor := GetDOMVendor(sOmniXmlVendor).Description;
+  XMLDoc := LoadXMLData(AValue);
+
+  for LMatcher in ValueMatchers do
+  begin
+    if not LMatcher.IsMatch(XMLDoc.DOMDocument) then
+      Exit(False);
+  end;
+
+  Result := True;
+end;
+
+function TWebMockXMLMatcher.ToString: string;
+begin
+  Result := '<XML>';
+end;
+
+{ TWebMockXMLValueMatcher }
+
+constructor TWebMockXMLValueMatcher.Create(const AXPath, AValue: string);
+begin
+  inherited Create;
+  FXPath := AXPath;
+  FValueMatcher := TWebMockStringWildcardMatcher.Create(AValue);
+end;
+
+constructor TWebMockXMLValueMatcher.Create(const AXPath: string;
+  APattern: TRegEx);
+begin
+  inherited Create;
+  FXPath := AXPath;
+  FValueMatcher := TWebMockStringRegExMatcher.Create(APattern);
+end;
+
+function TWebMockXMLValueMatcher.IsMatch(const ADocument: IDOMDocument): Boolean;
+var
+  LDOMNodeSelect: IDOMNodeSelect;
+  LNode, LValueNode: IDOMNode;
+begin
+  if not Assigned(ADocument) or not Supports(ADocument, IDOMNodeSelect, LDOMNodeSelect) then
+    Exit(False);
+
+  LNode := LDOMNodeSelect.selectNode(XPath);
+  if not Assigned(LNode) or not LNode.hasChildNodes then
+    Exit(False);
+
+  LValueNode := LNode.childNodes[0];
+
+  Result := ValueMatcher.IsMatch(LValueNode.nodeValue);
+end;
+
+end.

--- a/Tests/Features/WebMock.Assertions.Tests.pas
+++ b/Tests/Features/WebMock.Assertions.Tests.pas
@@ -34,6 +34,7 @@ uses
   WebMock;
 
 type
+
   [TestFixture]
   TWebMockAssertionsTests = class(TObject)
   private
@@ -83,6 +84,10 @@ type
     procedure WasRequestedWithJSON_MatchingRequest_Passes;
     [Test]
     procedure WasRequestedWithJSON_NotMatchingRequest_Fails;
+    [Test]
+    procedure WasRequestedWithXML_MatchingRequest_Passes;
+    [Test]
+    procedure WasRequestedWithXML_NotMatchingRequest_Fails;
     [Test]
     procedure DeleteWasRequested_MatchingRequest_Passes;
     [Test]
@@ -658,6 +663,48 @@ begin
     end,
     ETestFailure
   );
+end;
+
+procedure TWebMockAssertionsTests.WasRequestedWithXML_MatchingRequest_Passes;
+var
+  LXML: TStringStream;
+begin
+  LXML := TStringStream.Create('<Object><Attr1>Value 1</Attr1></Object>');
+  WebClient.Post(WebMock.URLFor('/xml'), LXML);
+
+  Assert.WillRaise(
+    procedure
+    begin
+      WebMock.Assert
+        .Post('/xml')
+        .WithXML('/Object/Attr1', 'Value 1')
+        .WasRequested;
+    end,
+    ETestPass
+  );
+
+  LXML.Free;
+end;
+
+procedure TWebMockAssertionsTests.WasRequestedWithXML_NotMatchingRequest_Fails;
+var
+  LXML: TStringStream;
+begin
+  LXML := TStringStream.Create('<Object><Attr1>Other Value</Attr1></Object>');
+  WebClient.Post(WebMock.URLFor('/xml'), LXML);
+
+  Assert.WillRaise(
+    procedure
+    begin
+      WebMock.Assert
+        .Post('/xml')
+        .WithXML('/Object/Attr1', 'Value 1')
+        .WasRequested;
+    end,
+    ETestFailure
+  );
+
+  LXML.Free;
 end;
 
 procedure TWebMockAssertionsTests.WasRequested_WithRegExURIMatchingRequest_Passes;

--- a/Tests/Features/WebMock.MatchingXML.Tests.pas
+++ b/Tests/Features/WebMock.MatchingXML.Tests.pas
@@ -1,0 +1,114 @@
+﻿unit WebMock.MatchingXML.Tests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Classes,
+  System.SysUtils,
+  WebMock;
+
+type
+  [TestFixture]
+  TWebMockMatchingXMLTests = class(TObject)
+  private
+    WebMock: TWebMock;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+    [Test]
+    procedure Request_MatchingXMLContent_RespondsOK;
+    [Test]
+    procedure Request_NotMatchingXMLContent_RespondsNotImplemented;
+    [Test]
+    procedure Request_MatchingXMLContentByRegEx_RespondsOK;
+  end;
+
+implementation
+
+uses
+  System.Net.HttpClient,
+  System.Net.URLClient,
+  System.RegularExpressions,
+  TestHelpers;
+
+{ TWebMockMatchingXMLTests }
+
+procedure TWebMockMatchingXMLTests.Request_MatchingXMLContentByRegEx_RespondsOK;
+var
+  LContent: string;
+  LContentStream: TStringStream;
+  LHeaders: TNetHeaders;
+  LResponse: IHTTPResponse;
+begin
+  LContent := '<Key>123</Key>';
+  LContentStream := TStringStream.Create(LContent);
+  LHeaders := TNetHeaders.Create(
+    TNetHeader.Create('content-type', 'text/xml')
+  );
+
+  WebMock.StubRequest('*', '*').WithXML('/Key', TRegEx.Create('\d+'));
+  LResponse := WebClient.Post(WebMock.BaseURL, LContentStream, nil, LHeaders);
+
+  Assert.AreEqual(200, LResponse.StatusCode);
+
+  LContentStream.Free;
+end;
+
+procedure TWebMockMatchingXMLTests.Request_MatchingXMLContent_RespondsOK;
+var
+  LContent: string;
+  LContentStream: TStringStream;
+  LHeaders: TNetHeaders;
+  LResponse: IHTTPResponse;
+begin
+  LContent := '<Key>Value</Key>';
+  LContentStream := TStringStream.Create(LContent);
+  LHeaders := TNetHeaders.Create(
+    TNetHeader.Create('content-type', 'text/xml')
+  );
+
+  WebMock.StubRequest('*', '*').WithXML('/Key', 'Value');
+  LResponse := WebClient.Post(WebMock.BaseURL, LContentStream, nil, LHeaders);
+
+  Assert.AreEqual(200, LResponse.StatusCode);
+
+  LContentStream.Free;
+end;
+
+procedure TWebMockMatchingXMLTests.Request_NotMatchingXMLContent_RespondsNotImplemented;
+var
+  LContent: string;
+  LContentStream: TStringStream;
+  LHeaders: TNetHeaders;
+  LResponse: IHTTPResponse;
+begin
+  LContent := '<Key>Value</Key>';
+  LContentStream := TStringStream.Create(LContent);
+  LHeaders := TNetHeaders.Create(
+    TNetHeader.Create('content-type', 'text/xml')
+  );
+
+  WebMock.StubRequest('*', '*').WithXML('/Key', 'OtherValue');
+  LResponse := WebClient.Post(WebMock.BaseURL, LContentStream, nil, LHeaders);
+
+  Assert.AreEqual(501, LResponse.StatusCode);
+
+  LContentStream.Free;
+end;
+
+procedure TWebMockMatchingXMLTests.Setup;
+begin
+  WebMock := TWebMock.Create;
+end;
+
+procedure TWebMockMatchingXMLTests.TearDown;
+begin
+  WebMock.Free;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TWebMockMatchingXMLTests);
+end.

--- a/Tests/WebMock.Assertion.Tests.pas
+++ b/Tests/WebMock.Assertion.Tests.pas
@@ -139,6 +139,14 @@ type
     procedure WithJSON_GivenPathAndString_ReturnsSelf;
     [Test]
     procedure WithJSON_GivenPathAndString_SetsValueForBodyMatcher;
+    [Test]
+    procedure WithXML_GivenPathAndString_ReturnsSelf;
+    [Test]
+    procedure WithXML_GivenPathAndString_SetsValueForBodyMatcher;
+    [Test]
+    procedure WithXML_GivenPathAndPattern_ReturnsSelf;
+    [Test]
+    procedure WithXML_GivenPathAndPattern_SetsValueForBodyMatcher;
   end;
 
 implementation
@@ -156,7 +164,8 @@ uses
   WebMock.JSONMatcher,
   WebMock.StringRegExMatcher,
   WebMock.StringMatcher,
-  WebMock.StringWildcardMatcher;
+  WebMock.StringWildcardMatcher,
+  WebMock.XMLMatcher;
 
 procedure TWebMockAssertionTests.Delete_Always_ReturnsSelf;
 begin
@@ -686,6 +695,47 @@ begin
     LParamValue,
     (Matcher.QueryParams[LParamName] as TWebMockStringWildcardMatcher).Value
   );
+
+  Assertion.Free;
+end;
+
+procedure TWebMockAssertionTests.WithXML_GivenPathAndPattern_ReturnsSelf;
+begin
+  Assert.AreSame(Assertion,
+                 Assertion.Put('/').WithXML('/Object/Attr1', TRegEx.Create('.*')));
+
+  Assertion.Free;
+end;
+
+procedure TWebMockAssertionTests.WithXML_GivenPathAndPattern_SetsValueForBodyMatcher;
+var
+  LHTTPMatcher: TWebMockHTTPRequestMatcher;
+begin
+  Assertion.Post('/').WithXML('/Object/Attr1', 'Value');
+
+  LHTTPMatcher := Assertion.Matcher as TWebMockHTTPRequestMatcher;
+
+  Assert.IsTrue(LHTTPMatcher.Body is TWebMockXMLMatcher);
+
+  Assertion.Free;
+end;
+
+procedure TWebMockAssertionTests.WithXML_GivenPathAndString_ReturnsSelf;
+begin
+  Assert.AreSame(Assertion, Assertion.Put('/').WithXML('/Object/Attr1', 'Value'));
+
+  Assertion.Free;
+end;
+
+procedure TWebMockAssertionTests.WithXML_GivenPathAndString_SetsValueForBodyMatcher;
+var
+  LHTTPMatcher: TWebMockHTTPRequestMatcher;
+begin
+  Assertion.Post('/').WithXML('/Object/Attr1', 'Value');
+
+  LHTTPMatcher := Assertion.Matcher as TWebMockHTTPRequestMatcher;
+
+  Assert.IsTrue(LHTTPMatcher.Body is TWebMockXMLMatcher);
 
   Assertion.Free;
 end;

--- a/Tests/WebMock.Static.RequestStub.Tests.pas
+++ b/Tests/WebMock.Static.RequestStub.Tests.pas
@@ -106,6 +106,14 @@ type
     procedure WithQueryParam_GivenRegEx_ReturnsSelf;
     [Test]
     procedure WithQueryParam_GivenRegEx_SetsMatcherForParam;
+    [Test]
+    procedure WithXML_GivenPathAndString_ReturnsSelf;
+    [Test]
+    procedure WithXML_GivenPathAndString_SetsMatcherForContent;
+    [Test]
+    procedure WithXML_GivenPathAndPattern_ReturnsSelf;
+    [Test]
+    procedure WithXML_GivenPathAndPattern_SetsMatcherForContent;
   end;
 
 implementation
@@ -123,7 +131,8 @@ uses
   WebMock.ResponseStatus,
   WebMock.StringMatcher,
   WebMock.StringWildcardMatcher,
-  WebMock.StringRegExMatcher;
+  WebMock.StringRegExMatcher,
+  WebMock.XMLMatcher;
 
 { TWebMockRequestStubTests }
 
@@ -458,6 +467,31 @@ begin
     LParamValue,
     (StubbedRequest.Matcher.QueryParams[LParamName] as TWebMockStringWildcardMatcher).Value
   );
+end;
+
+procedure TWebMockStaticRequestStubTests.WithXML_GivenPathAndPattern_ReturnsSelf;
+begin
+  Assert.AreSame(StubbedRequest,
+                 StubbedRequest.WithXML('/path', TRegEx.Create('.*')));
+end;
+
+procedure TWebMockStaticRequestStubTests.WithXML_GivenPathAndPattern_SetsMatcherForContent;
+begin
+  StubbedRequest.WithXML('/Key', TRegEx.Create('.*'));
+
+  Assert.IsTrue(StubbedRequest.Matcher.Body is TWebMockXMLMatcher);
+end;
+
+procedure TWebMockStaticRequestStubTests.WithXML_GivenPathAndString_ReturnsSelf;
+begin
+  Assert.AreSame(StubbedRequest, StubbedRequest.WithXML('/path', 'value'));
+end;
+
+procedure TWebMockStaticRequestStubTests.WithXML_GivenPathAndString_SetsMatcherForContent;
+begin
+  StubbedRequest.WithXML('/Key', 'Value');
+
+  Assert.IsTrue(StubbedRequest.Matcher.Body is TWebMockXMLMatcher);
 end;
 
 initialization

--- a/Tests/WebMock.XMLMatcher.Tests.pas
+++ b/Tests/WebMock.XMLMatcher.Tests.pas
@@ -1,0 +1,151 @@
+﻿unit WebMock.XMLMatcher.Tests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  IdCustomHTTPServer,
+  WebMock.XMLMatcher;
+
+type
+
+  [TestFixture]
+  TWebMockXMLMatcherTests = class(TObject)
+  private
+    Matcher: TWebMockXMLMatcher;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+    [Test]
+    procedure Class_Always_ImplementsStringMatcher;
+    [Test]
+    procedure Create_Always_InitializesEmpty;
+    [Test]
+    procedure Add_Always_AddsValueMatcher;
+    [Test]
+    procedure Add_CalledMultipleTimes_AddsMultipleValueMatchers;
+    [Test]
+    procedure Add_GivenPattern_AddsRegExMatcher;
+    [Test]
+    procedure IsMatch_WhenGivenValueMatchesValue_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WhenGivenValueDoesNotMatchValue_ReturnsFalse;
+    [Test]
+    procedure IsMatch_WithMultipleMatchingValues_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WithPartialMatchingValues_ReturnsFalse;
+    [Test]
+    procedure ToString_Always_ReturnsXML;
+  end;
+
+implementation
+
+uses
+  System.RegularExpressions,
+  WebMock.StringMatcher;
+
+{ TWebMockXMLMatcherTests }
+
+procedure TWebMockXMLMatcherTests.Add_Always_AddsValueMatcher;
+begin
+  Matcher.Add('/APath', '*');
+
+  Assert.AreEqual(1, Matcher.ValueMatchers.Count);
+end;
+
+procedure TWebMockXMLMatcherTests.Add_CalledMultipleTimes_AddsMultipleValueMatchers;
+begin
+  Matcher.Add('Path1', '*');
+  Matcher.Add('Path2', '*');
+  Matcher.Add('Path3', '*');
+
+  Assert.AreEqual(3, Matcher.ValueMatchers.Count);
+end;
+
+procedure TWebMockXMLMatcherTests.Add_GivenPattern_AddsRegExMatcher;
+begin
+  Matcher.Add('/APath', TRegEx.Create('.*'));
+
+  Assert.AreEqual(1, Matcher.ValueMatchers.Count);
+end;
+
+procedure TWebMockXMLMatcherTests.Class_Always_ImplementsStringMatcher;
+var
+  Subject: IInterface;
+begin
+  Subject := TWebMockXMLMatcher.Create;
+
+  Assert.Implements<IStringMatcher>(Subject);
+end;
+
+procedure TWebMockXMLMatcherTests.Create_Always_InitializesEmpty;
+begin
+  Assert.AreEqual(0, Matcher.ValueMatchers.Count);
+end;
+
+procedure TWebMockXMLMatcherTests.IsMatch_WhenGivenValueDoesNotMatchValue_ReturnsFalse;
+var
+  LXML: string;
+begin
+  LXML := '<Key>OtherValue</Key>';
+
+  Matcher.Add('/Key', 'Value');
+
+  Assert.IsFalse(Matcher.IsMatch(LXML));
+end;
+
+procedure TWebMockXMLMatcherTests.IsMatch_WhenGivenValueMatchesValue_ReturnsTrue;
+var
+  LXML: string;
+begin
+  LXML := '<Key>Value</Key>';
+
+  Matcher.Add('/Key', 'Value');
+
+  Assert.IsTrue(Matcher.IsMatch(LXML));
+end;
+
+procedure TWebMockXMLMatcherTests.IsMatch_WithMultipleMatchingValues_ReturnsTrue;
+var
+  LXML: string;
+begin
+  LXML := '<Object><Key1>Value 1</Key1><Key2>Value 2</Key2></Object>';
+
+  Matcher.Add('/Object/Key1', 'Value 1');
+  Matcher.Add('/Object/Key2', 'Value 2');
+
+  Assert.IsTrue(Matcher.IsMatch(LXML));
+end;
+
+procedure TWebMockXMLMatcherTests.IsMatch_WithPartialMatchingValues_ReturnsFalse;
+var
+  LXML: string;
+begin
+  LXML := '<Object><Key1>Value 1</Key1><Key2>Value 2</Key2></Object>';
+
+  Matcher.Add('/Object/Key1', 'Value 1');
+  Matcher.Add('/Object/Key2', 'Value 3');
+
+  Assert.IsFalse(Matcher.IsMatch(LXML));
+end;
+
+procedure TWebMockXMLMatcherTests.Setup;
+begin
+  Matcher := TWebMockXMLMatcher.Create;
+end;
+
+procedure TWebMockXMLMatcherTests.TearDown;
+begin
+  Matcher.Free;
+end;
+
+procedure TWebMockXMLMatcherTests.ToString_Always_ReturnsXML;
+begin
+  Assert.AreEqual('<XML>', Matcher.ToString);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TWebMockXMLMatcherTests);
+end.

--- a/Tests/WebMock.XMLValueMatcher.Tests.pas
+++ b/Tests/WebMock.XMLValueMatcher.Tests.pas
@@ -1,0 +1,92 @@
+﻿unit WebMock.XMLValueMatcher.Tests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  WebMock.XMLMatcher;
+type
+  [TestFixture]
+  TWebMockXMLValueMatcherTests = class(TObject)
+  public
+    [Test]
+    procedure Create_Always_RequiresPathAndValue;
+    [Test]
+    procedure ValueMatcher_WhenInitializedWithStringValue_ReturnsStringMatcher;
+    [Test]
+    procedure ValueMatcher_WhenInitializedWithPatternValue_ReturnsRegExMatcher;
+    [Test]
+    procedure IsMatch_MatchingNodeText_ReturnsTrue;
+    [Test]
+    procedure IsMatch_NotMatchingNodeText_ReturnsFalse;
+  end;
+
+implementation
+
+uses
+  System.RegularExpressions,
+  WebMock.StringRegExMatcher,
+  WebMock.StringWildcardMatcher,
+  Xml.XMLDoc,
+  Xml.xmldom,
+  Xml.XMLIntf,
+  Xml.omnixmldom;
+
+{ TWebMockXMLValueMatcherTests }
+
+procedure TWebMockXMLValueMatcherTests.Create_Always_RequiresPathAndValue;
+var
+  LMatcher: TWebMockXMLValueMatcher;
+begin
+  LMatcher := TWebMockXMLValueMatcher.Create('APath', '*');
+  LMatcher.Free;
+  Assert.Pass('Create takes path and value');
+end;
+
+procedure TWebMockXMLValueMatcherTests.IsMatch_MatchingNodeText_ReturnsTrue;
+var
+  XMLDoc: IXMLDocument;
+  LMatcher: IWebMockXMLValueMatcher;
+begin
+  DefaultDOMVendor := GetDOMVendor(sOmniXmlVendor).Description;
+  XMLDoc := LoadXMLData('<Key>Value</Key>');
+  LMatcher := TWebMockXMLValueMatcher.Create('/Key', 'Value');
+
+  Assert.IsTrue(LMatcher.IsMatch(XMLDoc.DOMDocument));
+end;
+
+procedure TWebMockXMLValueMatcherTests.IsMatch_NotMatchingNodeText_ReturnsFalse;
+var
+  XMLDoc: IXMLDocument;
+  LMatcher: IWebMockXMLValueMatcher;
+begin
+  DefaultDOMVendor := GetDOMVendor(sOmniXmlVendor).Description;
+  XMLDoc := LoadXMLData('<Key>Other Value</Key>');
+  LMatcher := TWebMockXMLValueMatcher.Create('/Key', 'Value');
+
+  Assert.IsFalse(LMatcher.IsMatch(XMLDoc.DOMDocument));
+end;
+
+procedure TWebMockXMLValueMatcherTests.ValueMatcher_WhenInitializedWithPatternValue_ReturnsRegExMatcher;
+var
+  LMatcher: TWebMockXMLValueMatcher;
+begin
+  LMatcher := TWebMockXMLValueMatcher.Create('/Path', TRegEx.Create('.*'));
+
+  Assert.IsTrue(LMatcher.ValueMatcher is TWebMockStringRegExMatcher);
+
+  LMatcher.Free;
+end;
+
+procedure TWebMockXMLValueMatcherTests.ValueMatcher_WhenInitializedWithStringValue_ReturnsStringMatcher;
+var
+  LMatcher: TWebMockXMLValueMatcher;
+begin
+  LMatcher := TWebMockXMLValueMatcher.Create('/Path', 'Value');
+
+  Assert.IsTrue(LMatcher.ValueMatcher is TWebMockStringWildcardMatcher);
+
+  LMatcher.Free;
+end;
+
+end.

--- a/Tests/WebMocks.Tests.dpr
+++ b/Tests/WebMocks.Tests.dpr
@@ -66,7 +66,11 @@ uses
   WebMock.MatchingJSON.Tests in 'Features\WebMock.MatchingJSON.Tests.pas',
   WebMock.JSONMatcher in '..\Source\WebMock.JSONMatcher.pas',
   WebMock.JSONMatcher.Tests in 'WebMock.JSONMatcher.Tests.pas',
-  WebMock.JSONValueMatcher.Tests in 'WebMock.JSONValueMatcher.Tests.pas';
+  WebMock.JSONValueMatcher.Tests in 'WebMock.JSONValueMatcher.Tests.pas',
+  WebMock.MatchingXML.Tests in 'Features\WebMock.MatchingXML.Tests.pas',
+  WebMock.XMLMatcher.Tests in 'WebMock.XMLMatcher.Tests.pas',
+  WebMock.XMLMatcher in '..\Source\WebMock.XMLMatcher.pas',
+  WebMock.XMLValueMatcher.Tests in 'WebMock.XMLValueMatcher.Tests.pas';
 
 var
   Runner: ITestRunner;
@@ -114,5 +118,4 @@ begin
     on E: Exception do
       System.Writeln(E.ClassName, ': ', E.Message);
   end;
-
 end.

--- a/Tests/WebMocks.Tests.dproj
+++ b/Tests/WebMocks.Tests.dproj
@@ -211,6 +211,10 @@
         <DCCReference Include="..\Source\WebMock.JSONMatcher.pas"/>
         <DCCReference Include="WebMock.JSONMatcher.Tests.pas"/>
         <DCCReference Include="WebMock.JSONValueMatcher.Tests.pas"/>
+        <DCCReference Include="Features\WebMock.MatchingXML.Tests.pas"/>
+        <DCCReference Include="WebMock.XMLMatcher.Tests.pas"/>
+        <DCCReference Include="..\Source\WebMock.XMLMatcher.pas"/>
+        <DCCReference Include="WebMock.XMLValueMatcher.Tests.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>


### PR DESCRIPTION
It is now possible to match requests by XML values. For example:
```Delphi
WebMock.StubRequest('POST', '*').WithXML('/Object/Attr1', 'Value 1');
```

The first argument is an XML XPath value. The previous example would
make a positive match against the following document:
```XML
<Object>
  <Attr1>Value 1</Attr1>
</Object>
```

NOTE: Multiple calls can be chained to match multiple values.

The second argument also accepts a RegEx pattern. For example:
```Delphi
WebMock.StubRequest('POST', '*')
  .WithXML('/Object/Attr1', TRegEx.Create('Value\s\d+'));
```

It is also possible to assert a request was made containing content with
XML values. For example:
```Delphi
WebMock.Assert
  .Post('/xml')
  .WithXML('/Object/Attr1', 'Value 1')
  .WasRequested;
```
