### PR TITLE
Add support for matching JSON content by RegEx

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,13 @@ The first argument can be a path. For example, in the following JSON, the path
 }
 ```
 
+NOTE: Strings patterns can be matched by passing a regular expression as the
+second argument. For example:
+```Delphi
+WebMock.StubRequest('*', '*')
+  .WithJSON('objects[0].key', TRegEx.Create('value\s\d+'));
+```
+
 #### Request matching by XML
 HTTP request can be matched by XML data values submitted. For example:
 ```Delphi

--- a/Source/WebMock.Assertion.pas
+++ b/Source/WebMock.Assertion.pas
@@ -65,6 +65,7 @@ type
     function WithJSON(const APath: string; AValue: Float64): TWebMockAssertion; overload;
     function WithJSON(const APath: string; AValue: Integer): TWebMockAssertion; overload;
     function WithJSON(const APath: string; AValue: string): TWebMockAssertion; overload;
+    function WithJSON(const APath: string; APattern: TRegEx): TWebMockAssertion; overload;
     function WithXML(const AXPath, AValue: string): TWebMockAssertion; overload;
     function WithXML(const AXPath: string; APattern: TRegEx): TWebMockAssertion; overload;
     procedure WasRequested;
@@ -293,6 +294,14 @@ function TWebMockAssertion.WithQueryParam(const AName,
   AValue: string): TWebMockAssertion;
 begin
   Matcher.Builder.WithQueryParam(AName, AValue);
+
+  Result := Self;
+end;
+
+function TWebMockAssertion.WithJSON(const APath: string;
+  APattern: TRegEx): TWebMockAssertion;
+begin
+  Matcher.Builder.WithJSON(APath, APattern);
 
   Result := Self;
 end;

--- a/Source/WebMock.HTTP.RequestMatcher.pas
+++ b/Source/WebMock.HTTP.RequestMatcher.pas
@@ -61,6 +61,7 @@ type
     function WithJSON(const APath: string; AValue: Float64): IWebMockHTTPRequestMatcherBuilder; overload;
     function WithJSON(const APath: string; AValue: Integer): IWebMockHTTPRequestMatcherBuilder; overload;
     function WithJSON(const APath: string; AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
+    function WithJSON(const APath: string; APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder; overload;
     function WithQueryParam(const AName, AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
     function WithQueryParam(const AName: string; const APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder; overload;
     function WithXML(const AName, AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
@@ -90,6 +91,7 @@ type
       function WithJSON(const APath: string; AValue: Float64): IWebMockHTTPRequestMatcherBuilder; overload;
       function WithJSON(const APath: string; AValue: Integer): IWebMockHTTPRequestMatcherBuilder; overload;
       function WithJSON(const APath: string; AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
+      function WithJSON(const APath: string; APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder; overload;
       function WithQueryParam(const AName, AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
       function WithQueryParam(const AName: string; const APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder; overload;
       function WithXML(const AXPath, AValue: string): IWebMockHTTPRequestMatcherBuilder; overload;
@@ -467,6 +469,17 @@ begin
     AName,
     TWebMockStringWildcardMatcher.Create(AValue)
   );
+
+  Result := Self;
+end;
+
+function TWebMockHTTPRequestMatcher.TBuilder.WithJSON(const APath: string;
+  APattern: TRegEx): IWebMockHTTPRequestMatcherBuilder;
+begin
+  if not (Matcher.Body is TWebMockJSONMatcher) then
+    Matcher.Body := TWebMockJSONMatcher.Create;
+
+  (Matcher.Body as TWebMockJSONMatcher).Add(APath, APattern);
 
   Result := Self;
 end;

--- a/Source/WebMock.Static.RequestStub.pas
+++ b/Source/WebMock.Static.RequestStub.pas
@@ -66,6 +66,7 @@ type
     function WithJSON(const APath: string; const AValue: Float64): TWebMockStaticRequestStub; overload;
     function WithJSON(const APath: string; const AValue: Integer): TWebMockStaticRequestStub; overload;
     function WithJSON(const APath: string; const AValue: string): TWebMockStaticRequestStub; overload;
+    function WithJSON(const APath: string; const APattern: TRegEx): TWebMockStaticRequestStub; overload;
     function WithQueryParam(const AName, AValue: string): TWebMockStaticRequestStub; overload;
     function WithQueryParam(const AName: string; const APattern: TRegEx): TWebMockStaticRequestStub; overload;
     function WithXML(const AXPath, AValue: string): TWebMockStaticRequestStub; overload;
@@ -300,6 +301,17 @@ begin
     Matcher.Body := TWebMockJSONMatcher.Create;
 
   (Matcher.Body as TWebMockJSONMatcher).Add<Boolean>(APath, AValue);
+
+  Result := Self;
+end;
+
+function TWebMockStaticRequestStub.WithJSON(const APath: string;
+  const APattern: TRegEx): TWebMockStaticRequestStub;
+begin
+  if not (Matcher.Body is TWebMockXMLMatcher) then
+    Matcher.Body := TWebMockJSONMatcher.Create;
+
+  (Matcher.Body as TWebMockJSONMatcher).Add(APath, APattern);
 
   Result := Self;
 end;

--- a/Tests/Features/WebMock.MatchingJSON.Tests.pas
+++ b/Tests/Features/WebMock.MatchingJSON.Tests.pas
@@ -47,6 +47,10 @@ type
     procedure Request_MatchingJSONContent_RespondsOK;
     [Test]
     procedure Request_NotMatchingJSONContent_RespondsNotImplemented;
+    [Test]
+    procedure Request_MatchingJSONContentByRegEx_RespondsOK;
+    [Test]
+    procedure Request_NotMatchingJSONContentByRegEx_RespondsNotImplemented;
   end;
 
 implementation
@@ -58,6 +62,27 @@ uses
   TestHelpers;
 
 { TWebMockMatchingJSONTests }
+
+procedure TWebMockMatchingJSONTests.Request_MatchingJSONContentByRegEx_RespondsOK;
+var
+  LContent: string;
+  LContentStream: TStringStream;
+  LHeaders: TNetHeaders;
+  LResponse: IHTTPResponse;
+begin
+  LContent := '{ "key": "123" }';
+  LContentStream := TStringStream.Create(LContent);
+  LHeaders := TNetHeaders.Create(
+    TNetHeader.Create('content-type', 'application/json')
+  );
+
+  WebMock.StubRequest('*', '*').WithJSON('key', TRegEx.Create('\d+'));
+  LResponse := WebClient.Post(WebMock.BaseURL, LContentStream, nil, LHeaders);
+
+  Assert.AreEqual(200, LResponse.StatusCode);
+
+  LContentStream.Free;
+end;
 
 procedure TWebMockMatchingJSONTests.Request_MatchingJSONContent_RespondsOK;
 var
@@ -76,6 +101,27 @@ begin
   LResponse := WebClient.Post(WebMock.BaseURL, LContentStream, nil, LHeaders);
 
   Assert.AreEqual(200, LResponse.StatusCode);
+
+  LContentStream.Free;
+end;
+
+procedure TWebMockMatchingJSONTests.Request_NotMatchingJSONContentByRegEx_RespondsNotImplemented;
+var
+  LContent: string;
+  LContentStream: TStringStream;
+  LHeaders: TNetHeaders;
+  LResponse: IHTTPResponse;
+begin
+  LContent := '{ "key": "abc" }';
+  LContentStream := TStringStream.Create(LContent);
+  LHeaders := TNetHeaders.Create(
+    TNetHeader.Create('content-type', 'application/json')
+  );
+
+  WebMock.StubRequest('*', '*').WithJSON('key', TRegEx.Create('\d+'));
+  LResponse := WebClient.Post(WebMock.BaseURL, LContentStream, nil, LHeaders);
+
+  Assert.AreEqual(501, LResponse.StatusCode);
 
   LContentStream.Free;
 end;

--- a/Tests/WebMock.Assertion.Tests.pas
+++ b/Tests/WebMock.Assertion.Tests.pas
@@ -140,6 +140,10 @@ type
     [Test]
     procedure WithJSON_GivenPathAndString_SetsValueForBodyMatcher;
     [Test]
+    procedure WithJSON_GivenPathAndPattern_ReturnsSelf;
+    [Test]
+    procedure WithJSON_GivenPathAndPattern_SetsValueForBodyMatcher;
+    [Test]
     procedure WithXML_GivenPathAndString_ReturnsSelf;
     [Test]
     procedure WithXML_GivenPathAndString_SetsValueForBodyMatcher;
@@ -651,6 +655,29 @@ begin
   LJSONMatcher := LHTTPMatcher.Body as TWebMockJSONMatcher;
   LJSONValueMatcher := LJSONMatcher.ValueMatchers[0] as TWebMockJSONValueMatcher<Integer>;
   Assert.AreEqual(LValue, LJSONValueMatcher.Value);
+
+  Assertion.Free;
+end;
+
+procedure TWebMockAssertionTests.WithJSON_GivenPathAndPattern_ReturnsSelf;
+begin
+  Assert.AreSame(
+    Assertion,
+    Assertion.Put('/').WithJSON('key', TRegEx.Create('\d+'))
+  );
+
+  Assertion.Free;
+end;
+
+procedure TWebMockAssertionTests.WithJSON_GivenPathAndPattern_SetsValueForBodyMatcher;
+var
+  LHTTPMatcher: TWebMockHTTPRequestMatcher;
+begin
+  Assertion.Post('/').WithJSON('key', TRegEx.Create('\d+'));
+
+  LHTTPMatcher := Assertion.Matcher as TWebMockHTTPRequestMatcher;
+
+  Assert.IsTrue(LHTTPMatcher.Body is TWebMockJSONMatcher);
 
   Assertion.Free;
 end;

--- a/Tests/WebMock.JSONMatcher.Tests.pas
+++ b/Tests/WebMock.JSONMatcher.Tests.pas
@@ -27,6 +27,8 @@ type
     [Test]
     procedure Add_CalledMultipleTimes_AddsMultipleValueMatchers;
     [Test]
+    procedure Add_GivenPattern_AddsRegExMatcher;
+    [Test]
     procedure IsMatch_WhenGivenValueMatchesValue_ReturnsTrue;
     [Test]
     procedure IsMatch_WhenGivenValueDoesNotMatchValue_ReturnsFalse;
@@ -41,6 +43,7 @@ type
 implementation
 
 uses
+  System.RegularExpressions,
   WebMock.StringMatcher;
 
 { TWebMockJSONMatcherTests }
@@ -59,6 +62,13 @@ begin
   Matcher.Add<string>('Path3', '*');
 
   Assert.AreEqual(3, Matcher.ValueMatchers.Count);
+end;
+
+procedure TWebMockJSONMatcherTests.Add_GivenPattern_AddsRegExMatcher;
+begin
+  Matcher.Add('/APath', TRegEx.Create('.*'));
+
+  Assert.AreEqual(1, Matcher.ValueMatchers.Count);
 end;
 
 procedure TWebMockJSONMatcherTests.Class_Always_ImplementsStringMatcher;

--- a/Tests/WebMock.JSONPatternMatcher.Tests.pas
+++ b/Tests/WebMock.JSONPatternMatcher.Tests.pas
@@ -1,0 +1,147 @@
+﻿unit WebMock.JSONPatternMatcher.Tests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  WebMock.JSONMatcher;
+
+type
+  [TestFixture]
+  TWebMockJSONPatternMatcherTests = class(TObject)
+  public
+    [Test]
+    procedure Create_Always_RequiresPathAndPattern;
+    [Test]
+    procedure IsMatch_MatchingString_ReturnsTrue;
+    [Test]
+    procedure IsMatch_NotMatchingString_ReturnsFalse;
+    [Test]
+    procedure IsMatch_MatchingObjectPath_ReturnsTrue;
+    [Test]
+    procedure IsMatch_NotMatchingObjectPath_ReturnsFalse;
+    [Test]
+    procedure IsMatch_MatchingArrayPath_ReturnsTrue;
+    [Test]
+    procedure IsMatch_NotMatchingArrayPath_ReturnsFalse;
+  end;
+
+implementation
+
+uses
+  System.JSON,
+  System.RegularExpressions;
+
+{ TWebMockJSONPatternMatcherTests }
+
+procedure TWebMockJSONPatternMatcherTests.Create_Always_RequiresPathAndPattern;
+var
+  LMatcher: TWebMockJSONPatternMatcher;
+begin
+  LMatcher := TWebMockJSONPatternMatcher.Create('APath', TRegEx.Create('\d+'));
+
+  LMatcher.Free;
+
+  Assert.Pass('Create takes path and value');
+end;
+
+procedure TWebMockJSONPatternMatcherTests.IsMatch_MatchingArrayPath_ReturnsTrue;
+var
+  LJSON: TJSONValue;
+  LMatcher: TWebMockJSONPatternMatcher;
+begin
+  LJSON := TJSONObject.ParseJSONValue(
+    '{ "objects": [{ "key": "abc" }, { "key": "123" }] }'
+  );
+
+  LMatcher := TWebMockJSONPatternMatcher.Create(
+    'objects[1].key',
+    TRegEx.Create('\d+')
+  );
+  Assert.IsTrue(LMatcher.IsMatch(LJSON));
+
+  LMatcher.Free;
+  LJSON.Free;
+end;
+
+procedure TWebMockJSONPatternMatcherTests.IsMatch_MatchingObjectPath_ReturnsTrue;
+var
+  LJSON: TJSONValue;
+  LMatcher: TWebMockJSONPatternMatcher;
+begin
+  LJSON := TJSONObject.ParseJSONValue('{ "object": { "key": "abc" } }');
+
+  LMatcher := TWebMockJSONPatternMatcher.Create(
+    'object.key',
+    TRegEx.Create('[a-z]+')
+  );
+  Assert.IsTrue(LMatcher.IsMatch(LJSON));
+
+  LMatcher.Free;
+  LJSON.Free;
+end;
+
+procedure TWebMockJSONPatternMatcherTests.IsMatch_MatchingString_ReturnsTrue;
+var
+  LJSON: TJSONValue;
+  LMatcher: TWebMockJSONPatternMatcher;
+begin
+  LJSON := TJSONObject.ParseJSONValue('{ "key": "value" }');
+
+  LMatcher := TWebMockJSONPatternMatcher.Create('key', TRegEx.Create('value'));
+  Assert.IsTrue(LMatcher.IsMatch(LJSON));
+
+  LMatcher.Free;
+  LJSON.Free;
+end;
+
+procedure TWebMockJSONPatternMatcherTests.IsMatch_NotMatchingArrayPath_ReturnsFalse;
+var
+  LJSON: TJSONValue;
+  LMatcher: TWebMockJSONPatternMatcher;
+begin
+  LJSON := TJSONObject.ParseJSONValue(
+    '{ "objects": [{ "key": "abc" }, { "key": "123" }] }'
+  );
+
+  LMatcher := TWebMockJSONPatternMatcher.Create('objects[0].key', TRegEx.Create('\d+'));
+  Assert.IsFalse(LMatcher.IsMatch(LJSON));
+
+  LMatcher.Free;
+  LJSON.Free;
+end;
+
+procedure TWebMockJSONPatternMatcherTests.IsMatch_NotMatchingObjectPath_ReturnsFalse;
+var
+  LJSON: TJSONValue;
+  LMatcher: TWebMockJSONPatternMatcher;
+begin
+  LJSON := TJSONObject.ParseJSONValue('{ "object": { "key": "value" } }');
+
+  LMatcher := TWebMockJSONPatternMatcher.Create(
+    'object.key',
+    TRegEx.Create('other value')
+  );
+  Assert.IsFalse(LMatcher.IsMatch(LJSON));
+
+  LMatcher.Free;
+  LJSON.Free;
+end;
+
+procedure TWebMockJSONPatternMatcherTests.IsMatch_NotMatchingString_ReturnsFalse;
+var
+  LJSON: TJSONValue;
+  LMatcher: TWebMockJSONPatternMatcher;
+begin
+  LJSON := TJSONObject.ParseJSONValue('{ "key": "value" }');
+
+  LMatcher := TWebMockJSONPatternMatcher.Create('key', TRegEx.Create('other value'));
+  Assert.IsFalse(LMatcher.IsMatch(LJSON));
+
+  LMatcher.Free;
+  LJSON.Free;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TWebMockJSONPatternMatcherTests);
+end.

--- a/Tests/WebMock.Static.RequestStub.Tests.pas
+++ b/Tests/WebMock.Static.RequestStub.Tests.pas
@@ -99,6 +99,10 @@ type
     [Test]
     procedure WithJSON_GivenPathAndString_SetsMatcherForContent;
     [Test]
+    procedure WithJSON_GivenPathAndPattern_ReturnsSelf;
+    [Test]
+    procedure WithJSON_GivenPathAndPattern_SetsMatcherForContent;
+    [Test]
     procedure WithQueryParam_GivenString_ReturnsSelf;
     [Test]
     procedure WithQueryParam_GivenString_SetsMatcherForParam;
@@ -409,6 +413,21 @@ end;
 procedure TWebMockStaticRequestStubTests.WithJSON_GivenPathAndInteger_SetsMatcherForContent;
 begin
   StubbedRequest.WithJSON('key', 1);
+
+  Assert.IsTrue(StubbedRequest.Matcher.Body is TWebMockJSONMatcher);
+end;
+
+procedure TWebMockStaticRequestStubTests.WithJSON_GivenPathAndPattern_ReturnsSelf;
+begin
+  Assert.AreSame(
+    StubbedRequest,
+    StubbedRequest.WithJSON('key', TRegEx.Create('.*'))
+  );
+end;
+
+procedure TWebMockStaticRequestStubTests.WithJSON_GivenPathAndPattern_SetsMatcherForContent;
+begin
+  StubbedRequest.WithJSON('key', TRegEx.Create('.*'));
 
   Assert.IsTrue(StubbedRequest.Matcher.Body is TWebMockJSONMatcher);
 end;

--- a/Tests/WebMocks.Tests.dpr
+++ b/Tests/WebMocks.Tests.dpr
@@ -70,7 +70,8 @@ uses
   WebMock.MatchingXML.Tests in 'Features\WebMock.MatchingXML.Tests.pas',
   WebMock.XMLMatcher.Tests in 'WebMock.XMLMatcher.Tests.pas',
   WebMock.XMLMatcher in '..\Source\WebMock.XMLMatcher.pas',
-  WebMock.XMLValueMatcher.Tests in 'WebMock.XMLValueMatcher.Tests.pas';
+  WebMock.XMLValueMatcher.Tests in 'WebMock.XMLValueMatcher.Tests.pas',
+  WebMock.JSONPatternMatcher.Tests in 'WebMock.JSONPatternMatcher.Tests.pas';
 
 var
   Runner: ITestRunner;

--- a/Tests/WebMocks.Tests.dproj
+++ b/Tests/WebMocks.Tests.dproj
@@ -236,6 +236,7 @@
         <DCCReference Include="WebMock.XMLMatcher.Tests.pas"/>
         <DCCReference Include="..\Source\WebMock.XMLMatcher.pas"/>
         <DCCReference Include="WebMock.XMLValueMatcher.Tests.pas"/>
+        <DCCReference Include="WebMock.JSONPatternMatcher.Tests.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>


### PR DESCRIPTION
It is now possible to match requests by JSON values matched against a
regular expression. For example:
```Delphi
WebMock.StubRequest('*', '*').WithJSON('key', TRegEx.Create('\d+'));
```

The previous example would make a positive match against the following
content:
```JSON
{ "key": "value" }
```

The first argument is a JSONPath value. This allows nested values to be
matched. For example:
```Delphi
WebMock.StubRequest('*', '*')
  .WithJSON('objects[0].key', TRegEx.Create('\d+'));
```

This example would make a positive match against the following content:
```JSON
{ "object": [{ "key": "123" }]}
```

NOTE: Multiple calls can be chained to match multiple patterns.

It is also possible to assert a request was made containg content with
JSON values. For example:
```Delphi
WebMock.Assert
  .Post('/json')
  .WithJSON('key', TRegEx.Create('\d+'))
  .WasRequested;
```
