### PR TITLE
fix: Allow duplicate query parameter matching

### DIFF
--- a/Source/WebMock.Static.RequestStub.pas
+++ b/Source/WebMock.Static.RequestStub.pas
@@ -253,10 +253,7 @@ end;
 function TWebMockStaticRequestStub.WithQueryParam(const AName: string;
   const APattern: TRegEx): TWebMockStaticRequestStub;
 begin
-  Matcher.QueryParams.AddOrSetValue(
-    AName,
-    TWebMockStringRegExMatcher.Create(APattern)
-  );
+  Matcher.QueryParams.Add(AName, APattern);
 
   Result := Self;
 end;
@@ -286,10 +283,7 @@ end;
 function TWebMockStaticRequestStub.WithQueryParam(const AName,
   AValue: string): TWebMockStaticRequestStub;
 begin
-  Matcher.QueryParams.AddOrSetValue(
-    AName,
-    TWebMockStringWildcardMatcher.Create(AValue)
-  );
+  Matcher.QueryParams.Add(AName, AValue);
 
   Result := Self;
 end;

--- a/Tests/Features/WebMock.Assertions.Tests.pas
+++ b/Tests/Features/WebMock.Assertions.Tests.pas
@@ -77,6 +77,10 @@ type
     [Test]
     procedure WasRequestedWithQueryParam_NotMatchingRequest_Fails;
     [Test]
+    procedure WasRequestedWithQueryParam_MatchingRequestWithDuplicateParams_Passes;
+    [Test]
+    procedure WasRequestedWithQueryParam_NotMatchingRequestWithDuplicateParams_Fails;
+    [Test]
     procedure WasRequestedWithFormData_MatchingRequest_Passes;
     [Test]
     procedure WasRequestedWithFormData_NotMatchingRequest_Fails;
@@ -631,6 +635,22 @@ begin
   LJSON.Free;
 end;
 
+procedure TWebMockAssertionsTests.WasRequestedWithQueryParam_MatchingRequestWithDuplicateParams_Passes;
+begin
+  WebClient.Get(WebMock.URLFor('/') + '?Param=Value1&Param=Value2');
+
+  Assert.WillRaise(
+    procedure
+    begin
+      WebMock.Assert.Get('/')
+        .WithQueryParam('Param', 'Value1')
+        .WithQueryParam('Param', 'Value2')
+        .WasRequested;
+    end,
+    ETestPass
+  );
+end;
+
 procedure TWebMockAssertionsTests.WasRequestedWithQueryParam_MatchingRequest_Passes;
 var
   LParamName, LParamValue: string;
@@ -645,6 +665,22 @@ begin
       WebMock.Assert.Get('/').WithQueryParam(LParamName, LParamValue).WasRequested;
     end,
     ETestPass
+  );
+end;
+
+procedure TWebMockAssertionsTests.WasRequestedWithQueryParam_NotMatchingRequestWithDuplicateParams_Fails;
+begin
+  WebClient.Get(WebMock.URLFor('/') + '?Param=Value1&Param=Value2');
+
+  Assert.WillRaise(
+    procedure
+    begin
+      WebMock.Assert.Get('/')
+        .WithQueryParam('Param', 'Value1')
+        .WithQueryParam('Param', 'NoMatch')
+        .WasRequested;
+    end,
+    ETestFailure
   );
 end;
 

--- a/Tests/Features/WebMock.Matching.Tests.pas
+++ b/Tests/Features/WebMock.Matching.Tests.pas
@@ -66,6 +66,8 @@ type
     [Test]
     procedure Request_NotMatchingQueryParam_RespondsNotImplemented;
     [Test]
+    procedure Request_MatchingMultipleQueryParamsWithDuplicatedNames_RespondsOK;
+    [Test]
     procedure Request_MatchingQueryParamByRegEx_RespondsOK;
     [Test]
     procedure Request_NotMatchingQueryParamByRegEx_RespondsNotImplemented;
@@ -137,6 +139,18 @@ begin
     .WithHeader(LHeaderName1, LHeaderValue1)
     .WithHeader(LHeaderName2, LHeaderValue2);
   LResponse := WebClient.Get(WebMock.BaseURL, nil, LHeaders);
+
+  Assert.AreEqual(200, LResponse.StatusCode);
+end;
+
+procedure TWebMockMatchingTests.Request_MatchingMultipleQueryParamsWithDuplicatedNames_RespondsOK;
+var
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest('*', '*')
+    .WithQueryParam('Param', 'Value1')
+    .WithQueryParam('Param', 'Value2');
+  LResponse := WebClient.Get(WebMock.URLFor('/endpoint?Param=Value1&Param=Value2'));
 
   Assert.AreEqual(200, LResponse.StatusCode);
 end;

--- a/Tests/WebMock.Assertion.Tests.pas
+++ b/Tests/WebMock.Assertion.Tests.pas
@@ -720,7 +720,7 @@ begin
 
   Assert.AreEqual(
     LParamValue,
-    (Matcher.QueryParams[LParamName] as TWebMockStringWildcardMatcher).Value
+    (Matcher.QueryParams.QueryParams.First.ValueMatcher as TWebMockStringWildcardMatcher).Value
   );
 
   Assertion.Free;
@@ -779,7 +779,7 @@ begin
 
   Assert.AreEqual(
     LParamPattern,
-    (Matcher.QueryParams[LParamName] as TWebMockStringRegExMatcher).RegEx
+    (Matcher.QueryParams.QueryParams.First.ValueMatcher as TWebMockStringRegExMatcher).RegEx
   );
 
   Assertion.Free;

--- a/Tests/WebMock.HTTP.RequestMatcher.Tests.pas
+++ b/Tests/WebMock.HTTP.RequestMatcher.Tests.pas
@@ -82,6 +82,12 @@ type
     procedure IsMatch_WhenQueryParamsAreSetWithRegExGivenMatchingRequestInfo_ReturnsTrue;
     [Test]
     procedure IsMatch_WhenQueryParamsAreSetWithRegExGivenNonMatchingRequestInfo_ReturnsFalse;
+    [Test]
+    procedure IsMatch_WhenDuplicateQueryParamsAreSetGivenMatchingRequestInfo_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WhenDuplicateQueryParamsAreSetGivenPartiallyMatchingRequestInfo_ReturnsFalse;
+    [Test]
+    procedure IsMatch_WhenDuplicateQueryParamsAreSetGivenNonMatchingRequestInfo_ReturnsFalse;
   end;
 
 implementation
@@ -201,6 +207,66 @@ begin
   LRequestInfo.Free;
 end;
 
+procedure TWebMockHTTPRequestMatcherTests.IsMatch_WhenDuplicateQueryParamsAreSetGivenMatchingRequestInfo_ReturnsTrue;
+var
+  LRequestInfo: TIdHTTPRequestInfo;
+  LRequest: IWebMockHTTPRequest;
+begin
+  LRequestInfo := TMockIdHTTPRequestInfo.Mock(
+    'GET',
+    '/match?Name=Value1&Name=Value2'
+  );
+  LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
+
+  RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
+  RequestMatcher.QueryParams.Add('Name', 'Value1');
+  RequestMatcher.QueryParams.Add('Name', 'Value2');
+
+  Assert.IsTrue(RequestMatcher.IsMatch(LRequest));
+
+  LRequestInfo.Free;
+end;
+
+procedure TWebMockHTTPRequestMatcherTests.IsMatch_WhenDuplicateQueryParamsAreSetGivenNonMatchingRequestInfo_ReturnsFalse;
+var
+  LRequestInfo: TIdHTTPRequestInfo;
+  LRequest: IWebMockHTTPRequest;
+begin
+  LRequestInfo := TMockIdHTTPRequestInfo.Mock(
+    'GET',
+    '/match?Does=NotMatch'
+  );
+  LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
+
+  RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
+  RequestMatcher.QueryParams.Add('Name', 'Value1');
+  RequestMatcher.QueryParams.Add('Name', 'Value2');
+
+  Assert.IsFalse(RequestMatcher.IsMatch(LRequest));
+
+  LRequestInfo.Free;
+end;
+
+procedure TWebMockHTTPRequestMatcherTests.IsMatch_WhenDuplicateQueryParamsAreSetGivenPartiallyMatchingRequestInfo_ReturnsFalse;
+var
+  LRequestInfo: TIdHTTPRequestInfo;
+  LRequest: IWebMockHTTPRequest;
+begin
+  LRequestInfo := TMockIdHTTPRequestInfo.Mock(
+    'GET',
+    '/match?Name=Value2'
+  );
+  LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
+
+  RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
+  RequestMatcher.QueryParams.Add('Name', 'Value1');
+  RequestMatcher.QueryParams.Add('Name', 'Value2');
+
+  Assert.IsFalse(RequestMatcher.IsMatch(LRequest));
+
+  LRequestInfo.Free;
+end;
+
 procedure TWebMockHTTPRequestMatcherTests.IsMatch_WhenHeadersAreSetGivenMatchingRequestInfo_ReturnsTrue;
 var
   LRequestInfo: TIdHTTPRequestInfo;
@@ -270,9 +336,7 @@ begin
   LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
 
   RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
-  RequestMatcher.QueryParams.AddOrSetValue(
-    LParamName, TWebMockStringWildcardMatcher.Create(AMatchValue)
-  );
+  RequestMatcher.QueryParams.Add(LParamName, AMatchValue);
 
   Assert.IsTrue(RequestMatcher.IsMatch(LRequest));
 
@@ -291,9 +355,7 @@ begin
   LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
 
   RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
-  RequestMatcher.QueryParams.AddOrSetValue(
-    LParamName, TWebMockStringWildcardMatcher.Create(LParamValue)
-  );
+  RequestMatcher.QueryParams.Add(LParamName, LParamValue);
 
   Assert.IsFalse(RequestMatcher.IsMatch(LRequest));
 
@@ -311,9 +373,7 @@ begin
   LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
 
   RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
-  RequestMatcher.QueryParams.AddOrSetValue(
-    LParamName, TWebMockStringWildcardMatcher.Create('')
-  );
+  RequestMatcher.QueryParams.Add(LParamName, '');
 
   Assert.IsTrue(RequestMatcher.IsMatch(LRequest));
 
@@ -331,9 +391,7 @@ begin
   LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
 
   RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
-  RequestMatcher.QueryParams.AddOrSetValue(
-    LParamName, TWebMockStringWildcardMatcher.Create('*')
-  );
+  RequestMatcher.QueryParams.Add(LParamName, '*');
 
   Assert.IsTrue(RequestMatcher.IsMatch(LRequest));
 
@@ -351,9 +409,7 @@ begin
   LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
 
   RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
-  RequestMatcher.QueryParams.AddOrSetValue(
-    LParamName, TWebMockStringWildcardMatcher.Create('*')
-  );
+  RequestMatcher.QueryParams.Add(LParamName, '*');
 
   Assert.IsFalse(RequestMatcher.IsMatch(LRequest));
 
@@ -374,9 +430,7 @@ begin
   LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
 
   RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
-  RequestMatcher.QueryParams.AddOrSetValue(
-    LParamName, TWebMockStringRegExMatcher.Create(TRegEx.Create('\d+'))
-  );
+  RequestMatcher.QueryParams.Add(LParamName, TRegEx.Create('\d+'));
 
   Assert.IsTrue(RequestMatcher.IsMatch(LRequest));
 
@@ -397,9 +451,7 @@ begin
   LRequest := TWebMockHTTPRequest.Create(LRequestInfo);
 
   RequestMatcher := TWebMockHTTPRequestMatcher.Create('/match', 'GET');
-  RequestMatcher.QueryParams.AddOrSetValue(
-    LParamName, TWebMockStringRegExMatcher.Create(TRegEx.Create('\d+'))
-  );
+  RequestMatcher.QueryParams.Add(LParamName, TRegEx.Create('\d+'));
 
   Assert.IsFalse(RequestMatcher.IsMatch(LRequest));
 

--- a/Tests/WebMock.HTTP.RequestQueryParamsMatcher.Tests.pas
+++ b/Tests/WebMock.HTTP.RequestQueryParamsMatcher.Tests.pas
@@ -1,0 +1,207 @@
+﻿unit WebMock.HTTP.RequestQueryParamsMatcher.Tests;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  WebMock.HTTP.RequestMatcher,
+  IdCustomHTTPServer;
+
+type
+
+  [TestFixture]
+  TWebMockHTTPRequestQueryParamsMatcherTests = class(TObject)
+  private
+    Matcher: TWebMockHTTPRequestQueryParamsMatcher;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+    [Test]
+    procedure Add_GivenNameAndStringValue_ReturnsIndexOfAddedQueryParamMatcher;
+    [Test]
+    procedure Add_GivenNameAndStringValue_AddsMatcherToQueryParams;
+    [Test]
+    procedure Add_GivenNameAndPattern_ReturnsIndexOfAddedQueryParamMatcher;
+    [Test]
+    procedure Add_GivenNameAndPattern_AddsMatcherToQueryParams;
+    [Test]
+    procedure IsMatch_WithNoParamsSet_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WithOneStringMatchingParamSetGivenMatchingURL_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WithOneStringMatchingParamSetGivenNonMatchingURL_ReturnsFalse;
+    [Test]
+    procedure IsMatch_WithOnePatternMatchingParamSetGivenMatchingURL_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WithOnePatternMatchingParamSetGivenNonMatchingURL_ReturnsFalse;
+    [Test]
+    procedure IsMatch_WithMultipleStringMatchingParamSetGivenMatchingURL_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WithMultipleStringMatchingParamSetGivenNonMatchingURL_ReturnsFalse;
+    [Test]
+    procedure IsMatch_WithMultipleStringMatchingParamSetGivenPartialMatchingURL_ReturnsFalse;
+    [Test]
+    procedure IsMatch_WithMultipleStringMatchingParamWithDuplicateNamesSetGivenMatchingURL_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WithMultiplePatternMatchingParamSetGivenMatchingURL_ReturnsTrue;
+    [Test]
+    procedure IsMatch_WithMultiplePatternMatchingParamSetGivenNonMatchingURL_ReturnsFalse;
+    [Test]
+    procedure IsMatch_WithMultiplePatternMatchingParamSetGivenPartialMatchingURL_ReturnsFalse;
+    [Test]
+    procedure IsMatch_WithMultiplePatternMatchingParamWithDuplicateNamesSetGivenMatchingURL_ReturnsTrue;
+  end;
+
+implementation
+
+uses
+  System.RegularExpressions,
+  WebMock.StringRegExMatcher,
+  WebMock.StringWildcardMatcher;
+
+{ TWebMockHTTPRequestQueryParamsMatcherTests }
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.Add_GivenNameAndPattern_AddsMatcherToQueryParams;
+var
+  LPattern: TRegEx;
+begin
+  LPattern := TRegEx.Create('Value');
+  Matcher.Add('Name', LPattern);
+
+  Assert.AreEqual('Name', Matcher.QueryParams.First.Name);
+  Assert.AreEqual(
+    LPattern,
+    (Matcher.QueryParams.First.ValueMatcher as TWebMockStringRegExMatcher).RegEx
+  );
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.Add_GivenNameAndPattern_ReturnsIndexOfAddedQueryParamMatcher;
+begin
+  Assert.AreEqual(0, Matcher.Add('Name', TRegEx.Create('Value')));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.Add_GivenNameAndStringValue_AddsMatcherToQueryParams;
+begin
+  Matcher.Add('Name', 'Value');
+
+  Assert.AreEqual('Name', Matcher.QueryParams.First.Name);
+  Assert.AreEqual('Value', (Matcher.QueryParams.First.ValueMatcher as TWebMockStringWildcardMatcher).Value);
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.Add_GivenNameAndStringValue_ReturnsIndexOfAddedQueryParamMatcher;
+begin
+  Assert.AreEqual(0, Matcher.Add('Name', 'Value'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithMultiplePatternMatchingParamSetGivenMatchingURL_ReturnsTrue;
+begin
+  Matcher.Add('Name1', TRegEx.Create('Value1'));
+  Matcher.Add('Name2', TRegEx.Create('Value2'));
+
+  Assert.IsTrue(Matcher.IsMatch('http://example.com?Name1=Value1&Name2=Value2'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithMultiplePatternMatchingParamSetGivenNonMatchingURL_ReturnsFalse;
+begin
+  Matcher.Add('Name1', TRegEx.Create('Value1'));
+  Matcher.Add('Name2', TRegEx.Create('Value2'));
+
+  Assert.IsFalse(Matcher.IsMatch('http://example.com'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithMultiplePatternMatchingParamSetGivenPartialMatchingURL_ReturnsFalse;
+begin
+  Matcher.Add('Name1', TRegEx.Create('Value1'));
+  Matcher.Add('Name2', TRegEx.Create('Value2'));
+
+  Assert.IsFalse(Matcher.IsMatch('http://example.com?Name1=Value1'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithMultiplePatternMatchingParamWithDuplicateNamesSetGivenMatchingURL_ReturnsTrue;
+begin
+  Matcher.Add('Name', TRegEx.Create('Value1'));
+  Matcher.Add('Name', TRegEx.Create('Value2'));
+
+  Assert.IsTrue(Matcher.IsMatch('http://example.com?Name=Value1&Name=Value2'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithMultipleStringMatchingParamSetGivenMatchingURL_ReturnsTrue;
+begin
+  Matcher.Add('Name1', 'Value1');
+  Matcher.Add('Name2', 'Value2');
+
+  Assert.IsTrue(Matcher.IsMatch('http://example.com?Name1=Value1&Name2=Value2'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithMultipleStringMatchingParamSetGivenNonMatchingURL_ReturnsFalse;
+begin
+  Matcher.Add('Name1', 'Value1');
+  Matcher.Add('Name2', 'Value2');
+
+  Assert.IsFalse(Matcher.IsMatch('http://example.com'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithMultipleStringMatchingParamSetGivenPartialMatchingURL_ReturnsFalse;
+begin
+  Matcher.Add('Name1', 'Value1');
+  Matcher.Add('Name2', 'Value2');
+
+  Assert.IsFalse(Matcher.IsMatch('http://example.com?Name1=Value1'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithMultipleStringMatchingParamWithDuplicateNamesSetGivenMatchingURL_ReturnsTrue;
+begin
+  Matcher.Add('Name', 'Value1');
+  Matcher.Add('Name', 'Value2');
+
+  Assert.IsTrue(Matcher.IsMatch('http://example.com?Name=Value1&Name=Value2'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithNoParamsSet_ReturnsTrue;
+begin
+  Assert.IsTrue(Matcher.IsMatch('http://example.com'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithOnePatternMatchingParamSetGivenMatchingURL_ReturnsTrue;
+begin
+  Matcher.Add('Name', TRegEx.Create('Value'));
+
+  Assert.IsTrue(Matcher.IsMatch('http://example.com?Name=Value'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithOnePatternMatchingParamSetGivenNonMatchingURL_ReturnsFalse;
+begin
+  Matcher.Add('Name', TRegEx.Create('Value'));
+
+  Assert.IsFalse(Matcher.IsMatch('http://example.com?Name=Other'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithOneStringMatchingParamSetGivenMatchingURL_ReturnsTrue;
+begin
+  Matcher.Add('Name', 'Value');
+
+  Assert.IsTrue(Matcher.IsMatch('http://example.com?Name=Value'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.IsMatch_WithOneStringMatchingParamSetGivenNonMatchingURL_ReturnsFalse;
+begin
+  Matcher.Add('Name', 'Value');
+
+  Assert.IsFalse(Matcher.IsMatch('http://example.com?Name=OtherValue'));
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.Setup;
+begin
+  Matcher := TWebMockHTTPRequestQueryParamsMatcher.Create;
+end;
+
+procedure TWebMockHTTPRequestQueryParamsMatcherTests.TearDown;
+begin
+  Matcher.Free;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TWebMockHTTPRequestQueryParamsMatcherTests);
+end.

--- a/Tests/WebMock.Static.RequestStub.Tests.pas
+++ b/Tests/WebMock.Static.RequestStub.Tests.pas
@@ -464,7 +464,7 @@ begin
 
   Assert.AreEqual(
     LParamPattern,
-    (StubbedRequest.Matcher.QueryParams[LParamName] as TWebMockStringRegExMatcher).RegEx
+    (StubbedRequest.Matcher.QueryParams.QueryParams.First.ValueMatcher as TWebMockStringRegExMatcher).RegEx
   );
 end;
 
@@ -484,7 +484,7 @@ begin
 
   Assert.AreEqual(
     LParamValue,
-    (StubbedRequest.Matcher.QueryParams[LParamName] as TWebMockStringWildcardMatcher).Value
+    (StubbedRequest.Matcher.QueryParams.QueryParams.First.ValueMatcher as TWebMockStringWildcardMatcher).Value
   );
 end;
 

--- a/Tests/WebMocks.Tests.dpr
+++ b/Tests/WebMocks.Tests.dpr
@@ -71,7 +71,8 @@ uses
   WebMock.XMLMatcher.Tests in 'WebMock.XMLMatcher.Tests.pas',
   WebMock.XMLMatcher in '..\Source\WebMock.XMLMatcher.pas',
   WebMock.XMLValueMatcher.Tests in 'WebMock.XMLValueMatcher.Tests.pas',
-  WebMock.JSONPatternMatcher.Tests in 'WebMock.JSONPatternMatcher.Tests.pas';
+  WebMock.JSONPatternMatcher.Tests in 'WebMock.JSONPatternMatcher.Tests.pas',
+  WebMock.HTTP.RequestQueryParamsMatcher.Tests in 'WebMock.HTTP.RequestQueryParamsMatcher.Tests.pas';
 
 var
   Runner: ITestRunner;

--- a/Tests/WebMocks.Tests.dproj
+++ b/Tests/WebMocks.Tests.dproj
@@ -258,6 +258,7 @@
         <DCCReference Include="..\Source\WebMock.XMLMatcher.pas"/>
         <DCCReference Include="WebMock.XMLValueMatcher.Tests.pas"/>
         <DCCReference Include="WebMock.JSONPatternMatcher.Tests.pas"/>
+        <DCCReference Include="WebMock.HTTP.RequestQueryParamsMatcher.Tests.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -314,6 +315,12 @@
                 <DeployFile LocalName="WebMocks.Tests.dSYM" Configuration="Debug" Class="ProjectOSXDebug"/>
                 <DeployFile LocalName="WebMocks.Tests.entitlements" Configuration="Debug" Class="ProjectOSXEntitlements"/>
                 <DeployFile LocalName="WebMocks.Tests.exe" Configuration="Debug" Class="ProjectOutput"/>
+                <DeployFile LocalName="WebMocks.Tests.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>WebMocks_Tests.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
                 <DeployFile LocalName="WebMocks.Tests.info.plist" Configuration="Debug" Class="ProjectOSXInfoPList"/>
                 <DeployFile LocalName="WebMocks.Tests" Configuration="Debug" Class="ProjectOutput"/>
                 <DeployClass Name="AdditionalDebugSymbols">


### PR DESCRIPTION
Fixes #54.

This change fixes the "Duplicates not allowed" exception caused when a URL
containing multiples of the same parameter name were being inspected. It
also expands the flexibility of query parameter matching.

Assertions written as the following, now behave as expected, matching
both "Value1" AND "Value2":
```Delphi
WebMock.Assert
  .WithQueryParam('Name', 'Value1')
  .WithQueryParam('Name', 'Value2')
  .WasRequested;
```
Previously, the behaviour would have incorrectly matched the last value
declared, ignoring previous values.
