### PR TITLE
fix: Allow setting Content-Length by header

### DIFF
--- a/Source/WebMock.pas
+++ b/Source/WebMock.pas
@@ -252,7 +252,10 @@ var
   LHeader: TPair<string, string>;
 begin
   for LHeader in AResponseHeaders do
-    AResponseInfo.CustomHeaders.AddValue(LHeader.Key, LHeader.Value);
+    if LHeader.Key.ToLower.Equals('content-length') then
+      AResponseInfo.ContentLength := LHeader.Value.ToInt64
+    else
+      AResponseInfo.CustomHeaders.AddValue(LHeader.Key, LHeader.Value);
 end;
 
 procedure TWebMock.SetResponseStatus(AResponseInfo: TIdHTTPResponseInfo;

--- a/Tests/Features/WebMock.ResponsesWithHeaders.Tests.pas
+++ b/Tests/Features/WebMock.ResponsesWithHeaders.Tests.pas
@@ -50,6 +50,8 @@ type
     procedure Response_WithHeaderChained_HasValueForEachHeader;
     [Test]
     procedure Response_WithHeaders_HasValueForAllHeaders;
+    [Test]
+    procedure Response_WithContentLengthHeader_SetsResponseContentLength;
   end;
 
 implementation
@@ -59,6 +61,17 @@ implementation
 uses
   System.Net.HttpClient,
   TestHelpers;
+
+procedure TWebMockResponsesWithHeadersTests.Response_WithContentLengthHeader_SetsResponseContentLength;
+var
+  LResponse: IHTTPResponse;
+begin
+  WebMock.StubRequest('HEAD', '*').ToRespond
+    .WithHeader('content-length', '12345');
+  LResponse := WebClient.Head(WebMock.BaseURL);
+
+  Assert.AreEqual<Int64>(12345, LResponse.ContentLength);
+end;
 
 procedure TWebMockResponsesWithHeadersTests.Response_WithHeaderChained_HasValueForEachHeader;
 var


### PR DESCRIPTION
Fixes #56.

It is now possible to set a stubbed responses content length by
`SetHeader`.

Foe example:
```Delphi
WebMock.StubRequest('HEAD', '/download')
  .ToRespond
  .WithHeader('content-length', '123');
```
