### PR TITLE
fix: Restore History interface

### DIFF
--- a/Source/WebMock.Assertion.pas
+++ b/Source/WebMock.Assertion.pas
@@ -30,6 +30,7 @@ interface
 uses
   DUnitX.TestFramework,
   System.Classes,
+  System.Generics.Collections,
   System.RegularExpressions,
   System.Rtti,
   WebMock.HTTP.Messages,
@@ -40,10 +41,10 @@ type
   TWebMockAssertion = class(TObject)
   private
     FMatcher: IWebMockHTTPRequestMatcher;
-    FHistory: IInterfaceList;
+    FHistory: TList<IWebMockHTTPRequest>;
     function MatchesHistory: Boolean;
   public
-    constructor Create(const AHistory: IInterfaceList);
+    constructor Create(const AHistory: TList<IWebMockHTTPRequest>);
     function Delete(const AURI: string): TWebMockAssertion;
     function Get(const AURI: string): TWebMockAssertion;
     function Head(const AURI: string): TWebMockAssertion;
@@ -70,7 +71,7 @@ type
     function WithXML(const AXPath: string; APattern: TRegEx): TWebMockAssertion; overload;
     procedure WasRequested;
     procedure WasNotRequested;
-    property History: IInterfaceList read FHistory;
+    property History: TList<IWebMockHTTPRequest> read FHistory;
     property Matcher: IWebMockHTTPRequestMatcher read FMatcher;
   end;
 
@@ -84,7 +85,7 @@ uses
   WebMock.StringRegExMatcher,
   WebMock.StringWildcardMatcher;
 
-constructor TWebMockAssertion.Create(const AHistory: IInterfaceList);
+constructor TWebMockAssertion.Create(const AHistory: TList<IWebMockHTTPRequest>);
 begin
   inherited Create;
   FHistory := AHistory;

--- a/Source/WebMock.pas
+++ b/Source/WebMock.pas
@@ -57,7 +57,7 @@ type
     FServer: TIdHTTPServer;
     FBaseURL: string;
     FStubRegistry: TInterfaceList; // IWebMockRequestStub
-    FHistory: IInterfaceList;
+    FHistory: TList<IWebMockHTTPRequest>;
     procedure InitializeServer(const APort: TWebWockPort);
     procedure StartServer(const APort: TWebWockPort);
     procedure OnServerRequest(AContext: TIdContext;
@@ -93,7 +93,7 @@ type
       : TWebMockDynamicRequestStub; overload;
     function URLFor(AURI: string): string;
     property BaseURL: string read FBaseURL;
-    property History: IInterfaceList read FHistory;
+    property History: TList<IWebMockHTTPRequest> read FHistory;
     property StubRegistry: TInterfaceList read FStubRegistry;
     property Port: Integer read GetPort;
   end;
@@ -124,14 +124,15 @@ end;
 constructor TWebMock.Create(const APort: TWebWockPort = 0);
 begin
   inherited Create;
+  FHistory := TList<IWebMockHTTPRequest>.Create;
   FStubRegistry := TInterfaceList.Create;
-  FHistory := TInterfaceList.Create;
   InitializeServer(APort);
 end;
 
 destructor TWebMock.Destroy;
 begin
   FStubRegistry.Free;
+  FHistory.Free;
   FServer.Free;
   inherited;
 end;

--- a/Tests/Features/WebMock.History.Tests.pas
+++ b/Tests/Features/WebMock.History.Tests.pas
@@ -66,7 +66,7 @@ var
 begin
   WebClient.Get(WebMock.URLFor('resource'));
 
-  LastRequest := WebMock.History[WebMock.History.Count - 1] as IWebMockHTTPRequest;
+  LastRequest := WebMock.History.Last;
   Assert.AreEqual('GET', LastRequest.Method);
   Assert.AreEqual('/resource', LastRequest.RequestURI);
 end;

--- a/Tests/WebMock.Assertion.Tests.pas
+++ b/Tests/WebMock.Assertion.Tests.pas
@@ -40,7 +40,7 @@ type
   [TestFixture]
   TWebMockAssertionTests = class(TObject)
   private
-    History: IInterfaceList;
+    History: TList<IWebMockHTTPRequest>;
     Assertion: TWebMockAssertion;
     function GetMatcher: TWebMockHTTPRequestMatcher;
     property Matcher: TWebMockHTTPRequestMatcher read GetMatcher;
@@ -341,13 +341,13 @@ end;
 
 procedure TWebMockAssertionTests.Setup;
 begin
-  History := TInterfaceList.Create;
+  History := TList<IWebMockHTTPRequest>.Create;
   Assertion := TWebMockAssertion.Create(History);
 end;
 
 procedure TWebMockAssertionTests.TearDown;
 begin
-  History := nil;
+  History.Free;
 end;
 
 procedure TWebMockAssertionTests.WasRequested_NotMatchingHistory_RaisesFailingException;


### PR DESCRIPTION
Fixes #53.

The history interface has been restored to behave as documented.
